### PR TITLE
fix #44 - Handing Disconnected Connections

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Loophole Labs Community Support
-    url: https://loopholelabs.slack.com/
+    url: https://discord.gg/JYmFhtdPeu
     about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: ''
 labels: enhancement
-assignees: ''
+assignees: ShivanshVij
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,6 +1,6 @@
 ---
 name: Other
-about: An different type of issue
+about: A different type of issue
 title: ''
 labels: question
 assignees: ShivanshVij

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,14 @@
+---
+name: Other
+about: An different type of issue
+title: ''
+labels: question
+assignees: ShivanshVij
+
+---
+
+**Description of the Issue. Please be as clear as possible.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Additional context**
+Add any other context or screenshots about the issue here.

--- a/async.go
+++ b/async.go
@@ -493,25 +493,17 @@ func (c *Async) readLoop() {
 								return
 							}
 							n = 0
+							err = c.SetReadDeadline(emptyTime)
+							if err != nil {
+								_ = c.closeWithError(err)
+								return
+							}
 							for n < min {
 								var nn int
-								err = c.SetReadDeadline(time.Now().Add(defaultDeadline))
-								if err != nil {
-									_ = c.closeWithError(err)
-									return
-								}
 								nn, err = c.conn.Read(buf[n:])
 								n += nn
 								if err != nil {
 									if n < min {
-										if os.IsTimeout(err) {
-											err = c.handleTimeout()
-											if err != nil {
-												_ = c.closeWithError(err)
-												return
-											}
-											continue
-										}
 										_ = c.closeWithError(err)
 										return
 									}

--- a/async.go
+++ b/async.go
@@ -338,6 +338,7 @@ func (c *Async) flushLoop() {
 }
 
 func (c *Async) handleTimeout() error {
+	c.Logger().Debug().Msg("Handling Timeout Using NOOP Message")
 	err := c.WriteMessage(NOOPMessage, nil)
 	if err != nil {
 		return err
@@ -347,6 +348,8 @@ func (c *Async) handleTimeout() error {
 	if err != nil {
 		return err
 	}
+
+	c.Logger().Debug().Msg("NOOP Message sent successfully, connection is still alive")
 
 	return nil
 }

--- a/async_test.go
+++ b/async_test.go
@@ -326,6 +326,8 @@ func TestAsyncTimeout(t *testing.T) {
 	err = writerConn.conn.Close()
 	assert.NoError(t, err)
 
+	time.Sleep(defaultDeadline)
+
 	_, _, err = readerConn.ReadMessage()
 	assert.ErrorIs(t, err, ConnectionClosed)
 	assert.ErrorIs(t, readerConn.Error(), ConnectionClosed)

--- a/async_test.go
+++ b/async_test.go
@@ -226,7 +226,7 @@ func TestAsyncReadClose(t *testing.T) {
 		err = writerConn.Flush()
 		assert.Error(t, err)
 	}
-	assert.ErrorIs(t, writerConn.Error(), ConnectionPaused)
+	assert.ErrorIs(t, writerConn.Error(), ConnectionClosed)
 
 	err = readerConn.Close()
 	assert.NoError(t, err)
@@ -268,8 +268,8 @@ func TestAsyncWriteClose(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, _, err = readerConn.ReadMessage()
-	assert.ErrorIs(t, err, ConnectionPaused)
-	assert.ErrorIs(t, readerConn.Error(), ConnectionPaused)
+	assert.ErrorIs(t, err, ConnectionClosed)
+	assert.ErrorIs(t, readerConn.Error(), ConnectionClosed)
 
 	err = readerConn.Close()
 	assert.NoError(t, err)

--- a/client.go
+++ b/client.go
@@ -213,9 +213,7 @@ func (c *Client) heartbeat() {
 			return
 		}
 		if c.conn.WriteBufferSize() == 0 {
-			err := c.WriteMessage(&Message{
-				Operation: HEARTBEAT,
-			}, nil)
+			err := c.WriteMessage(HEARTBEATMessage, nil)
 			if err != nil {
 				c.Logger().Error().Msgf(errors.WithContext(err, WRITECONN).Error())
 				_ = c.Close()

--- a/conn.go
+++ b/conn.go
@@ -41,7 +41,7 @@ const (
 
 var (
 	defaultLogger   = zerolog.New(os.Stdout)
-	defaultDeadline = time.Millisecond * 500
+	defaultDeadline = time.Second
 	emptyTime       = time.Time{}
 )
 

--- a/conn.go
+++ b/conn.go
@@ -41,7 +41,7 @@ const (
 
 var (
 	defaultLogger   = zerolog.New(os.Stdout)
-	defaultDeadline = time.Second * 5
+	defaultDeadline = time.Millisecond * 500
 	emptyTime       = time.Time{}
 )
 

--- a/conn.go
+++ b/conn.go
@@ -37,15 +37,12 @@ const (
 
 	// CLOSED is used to specify that the connection has been closed (possibly due to an error)
 	CLOSED
-
-	// PAUSED is used in the event of a read or write error and puts the connection into a paused state,
-	// this is then used by the reconnection logic to resume the connection
-	PAUSED
 )
 
 var (
 	defaultLogger   = zerolog.New(os.Stdout)
-	defaultDeadline = time.Second * 30
+	defaultDeadline = time.Second * 5
+	emptyTime       = time.Time{}
 )
 
 var (

--- a/frisbee.go
+++ b/frisbee.go
@@ -99,9 +99,12 @@ const (
 	// STREAMCLOSE is used to close a multiplexed stream
 	STREAMCLOSE
 
-	NOOP
+	// PING is used to check if a client is still alive
+	PING
 
-	RESERVED4
+	// PONG is used to respond to a PING message
+	PONG
+
 	RESERVED5
 	RESERVED6
 	RESERVED7
@@ -115,8 +118,13 @@ var (
 		Operation: HEARTBEAT,
 	}
 
-	// NOOPMessage is a pre-allocated Frisbee Message for NOOP Messages
-	NOOPMessage = &Message{
-		Operation: NOOP,
+	// PINGMessage is a pre-allocated Frisbee Message for PING Messages
+	PINGMessage = &Message{
+		Operation: PING,
+	}
+
+	// PONGMessage is a pre-allocated Frisbee Message for PONG Messages
+	PONGMessage = &Message{
+		Operation: PONG,
 	}
 )

--- a/frisbee.go
+++ b/frisbee.go
@@ -99,7 +99,8 @@ const (
 	// STREAMCLOSE is used to close a multiplexed stream
 	STREAMCLOSE
 
-	RESERVED3
+	NOOP
+
 	RESERVED4
 	RESERVED5
 	RESERVED6
@@ -112,5 +113,10 @@ var (
 	// HEARTBEATMessage is a pre-allocated Frisbee Message for HEARTBEAT Messages
 	HEARTBEATMessage = &Message{
 		Operation: HEARTBEAT,
+	}
+
+	// NOOPMessage is a pre-allocated Frisbee Message for NOOP Messages
+	NOOPMessage = &Message{
+		Operation: NOOP,
 	}
 )

--- a/frisbee.go
+++ b/frisbee.go
@@ -49,7 +49,6 @@ const (
 var (
 	InvalidContentLength     = errors.New("invalid content length")
 	ConnectionClosed         = errors.New("connection closed")
-	ConnectionPaused         = errors.New("connection paused")
 	ConnectionNotInitialized = errors.New("connection not initialized")
 	InvalidBufferContents    = errors.New("invalid buffer contents")
 	InvalidBufferLength      = errors.New("invalid buffer length")
@@ -107,4 +106,11 @@ const (
 	RESERVED7
 	RESERVED8
 	RESERVED9
+)
+
+var (
+	// HEARTBEATMessage is a pre-allocated Frisbee Message for HEARTBEAT Messages
+	HEARTBEATMessage = &Message{
+		Operation: HEARTBEAT,
+	}
 )

--- a/options.go
+++ b/options.go
@@ -59,7 +59,7 @@ func loadOptions(options ...Option) *Options {
 	}
 
 	if opts.Heartbeat == 0 {
-		opts.Heartbeat = time.Second * 5
+		opts.Heartbeat = time.Millisecond * 500
 	}
 
 	return opts

--- a/options_test.go
+++ b/options_test.go
@@ -29,7 +29,7 @@ func TestWithoutOptions(t *testing.T) {
 	options := loadOptions()
 
 	assert.Equal(t, time.Minute*3, options.KeepAlive)
-	assert.Equal(t, time.Second*5, options.Heartbeat)
+	assert.Equal(t, time.Millisecond*500, options.Heartbeat)
 	assert.Equal(t, &DefaultLogger, options.Logger)
 	assert.Nil(t, options.TLSConfig)
 }

--- a/sync_test.go
+++ b/sync_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"io"
 	"io/ioutil"
 	"net"
 	"testing"
@@ -260,7 +261,7 @@ func TestSyncReadClose(t *testing.T) {
 
 	err = writerConn.WriteMessage(message, nil)
 	assert.Error(t, err)
-	assert.ErrorIs(t, writerConn.Error(), ConnectionPaused)
+	assert.ErrorIs(t, writerConn.Error(), io.ErrClosedPipe)
 
 	err = readerConn.Close()
 	assert.NoError(t, err)
@@ -306,8 +307,8 @@ func TestSyncWriteClose(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, _, err = readerConn.ReadMessage()
-	assert.ErrorIs(t, err, ConnectionPaused)
-	assert.ErrorIs(t, readerConn.Error(), ConnectionPaused)
+	assert.ErrorIs(t, err, io.EOF)
+	assert.ErrorIs(t, readerConn.Error(), io.EOF)
 
 	err = readerConn.Close()
 	assert.NoError(t, err)


### PR DESCRIPTION
## Description

When a connection is closed properly it will send a notification before it closes, and that notification will signal to a socket being *read* that the connection is closed. 

However, to detect a connection is closed when the other side does not send a close notification, you must *write* to the socket. 

Moreover, it is possible that the socket itself is still open and can be written to, however the application on the other end is not responding in a timely manner. 

Taking into account all three scenarios, to properly handle disconnected connections we must first use a read timeout before every attempt to read an async connection. If the reading times out, we should attempt to write a `PING` message to that connection. We should then wait in a *separate* goroutine for a `PONG` message to arrive, because we need to unblock the read loop that called us in the first place. 

In this way, we guarantee that a PING request is answered with a PONG request in the event of a read timeout. This entire process won't ever occur during normal operation because the `HEARTBEAT` messages will take care of it, however if those messages are disabled or not sent properly then it becomes important to use the `PING` `PONG` pattern. 

This PR also removes the confusing `Connection Paused` state that the connection would previously go into and never come out of. This would cause the connection to not properly error out until the next write. It wasn't helping or being used anywhere so it's been removed. 

This PR also improves logging to be more descriptive, however a separate Issue has been opened (https://github.com/loopholelabs/frisbee/issues/48) to fix error handling and error logging throughout Frisbee. 

Fixes #44 

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] Bug fix (non-breaking change which fixes an issue) [title: 'fix:']
- [ ] New feature (non-breaking change which adds functionality) [title: 'feat:']
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please make sure that existing test cases pass (with `go test ./... -race` and `go test -bench=. ./... -race`), 
and if required please add new test cases and list them below:

- [x] TestAsyncTimeout

## Benchmarking

Frisbee tries to adhere to strict performance requirements, so please make sure to run `go test -bench=. ./...` and paste the results below:

### Benchmarking Results:

```shell
goarch: arm64
pkg: github.com/loopholelabs/frisbee/internal/protocol
BenchmarkEncodeHandler-10               75852466                15.51 ns/op
BenchmarkDecodeHandler-10               100000000               12.00 ns/op
BenchmarkEncodeDecodeHandler-10         41259325                28.79 ns/op
BenchmarkEncode-10                      95485964                12.16 ns/op
BenchmarkDecode-10                      136763902                8.840 ns/op
BenchmarkEncodeDecode-10                49431536                24.79 ns/op
PASS
ok      github.com/loopholelabs/frisbee/internal/protocol       9.134s
PASS
ok      github.com/loopholelabs/frisbee/internal/ringbuffer     0.111s
```

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `go fmt ./...` has been run
- [x] `golangci-lint run --skip-dirs-use-default` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
