### PR TITLE
fix #51 - making the loop blocking

### DIFF
--- a/async.go
+++ b/async.go
@@ -85,7 +85,7 @@ func NewAsync(c net.Conn, logger *zerolog.Logger) (conn *Async) {
 		flusher:          make(chan struct{}, 1024),
 		logger:           logger,
 		error:            atomic.NewError(nil),
-		pongCh:           make(chan struct{}),
+		pongCh:           make(chan struct{}, 1),
 		errorCh:          make(chan error, 1),
 	}
 
@@ -439,7 +439,13 @@ func (c *Async) readLoop() {
 				}
 			case PONG:
 				c.Logger().Debug().Msg("PONG Message received by read loop")
-				c.pongCh <- struct{}{}
+				timer := time.NewTimer(defaultDeadline)
+				select {
+				case <-timer.C:
+					c.Logger().Debug().Msg("Dropping PONG Message because it was not received successfully")
+				case c.pongCh <- struct{}{}:
+				}
+				timer.Stop()
 			case STREAMCLOSE:
 				c.streamConnMutex.RLock()
 				streamConn := c.streamConns[decodedMessage.Id]

--- a/async.go
+++ b/async.go
@@ -85,7 +85,7 @@ func NewAsync(c net.Conn, logger *zerolog.Logger) (conn *Async) {
 		flusher:          make(chan struct{}, 1024),
 		logger:           logger,
 		error:            atomic.NewError(nil),
-		pongCh:           make(chan struct{}, 1),
+		pongCh:           make(chan struct{}),
 		errorCh:          make(chan error, 1),
 	}
 
@@ -439,10 +439,7 @@ func (c *Async) readLoop() {
 				}
 			case PONG:
 				c.Logger().Debug().Msg("PONG Message received by read loop")
-				select {
-				case c.pongCh <- struct{}{}:
-				default:
-				}
+				c.pongCh <- struct{}{}
 			case STREAMCLOSE:
 				c.streamConnMutex.RLock()
 				streamConn := c.streamConns[decodedMessage.Id]


### PR DESCRIPTION
## Description

When the Read loop receives a `PING` message, it can only do so (under normal operation) when it sent a `PONG` message in the past (for that specific connection). Because it would have started a goroutine to wait for that, it's important to wait for the pong messages to be consumed properly (and not dropped because dropping it will cause the connection to get closed). 

To make sure the read loop is immediately unblocked, PONG messages spin up a goroutine. 

Fixes #51 

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] Bug fix (non-breaking change which fixes an issue) [title: 'fix:']
- [ ] New feature (non-breaking change which adds functionality) [title: 'feat:']
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

No tests tequired. 

## Benchmarking

Frisbee tries to adhere to strict performance requirements, so please make sure to run `go test -bench=. ./...` and paste the results below:

### Benchmarking Results:

```shell
goos: darwin
goarch: arm64
pkg: github.com/loopholelabs/frisbee
BenchmarkAsyncThroughputPipe32-10                     82          15818756 ns/op
BenchmarkAsyncThroughputPipe512-10                    50          22654869 ns/op
BenchmarkAsyncThroughputNetwork32-10                 100          14063662 ns/op
BenchmarkAsyncThroughputNetwork512-10                 51          22878575 ns/op
BenchmarkAsyncThroughputNetwork1024-10                36          31977206 ns/op
BenchmarkAsyncThroughputNetwork2048-10                21          51134960 ns/op
BenchmarkAsyncThroughputNetwork4096-10                12          87687000 ns/op
BenchmarkAsyncThroughputNetwork1mb-10                939           1140817 ns/op
BenchmarkClientThroughput/test-10                     54          22587296 ns/op
BenchmarkClientThroughputResponse/test-10             52          22302713 ns/op
BenchmarkThroughput/test-10                           46          22690248 ns/op
BenchmarkThroughputWithResponse/test-10               55          23189720 ns/op
BenchmarkSyncThroughputPipe32-10                       6         167429556 ns/op
BenchmarkSyncThroughputPipe512-10                      6         173737444 ns/op
BenchmarkSyncThroughputNetwork32-10                    3         404545083 ns/op
BenchmarkSyncThroughputNetwork512-10                   3         466016222 ns/op
BenchmarkSyncThroughputNetwork1024-10                  3         407258486 ns/op
BenchmarkSyncThroughputNetwork2048-10                  3         405029750 ns/op
BenchmarkSyncThroughputNetwork4096-10                  4         417491323 ns/op
BenchmarkSyncThroughputNetwork1mb-10                1315            943837 ns/op
PASS
ok      github.com/loopholelabs/frisbee 50.283s
?       github.com/loopholelabs/frisbee/internal/errors [no test files]
goos: darwin
goarch: arm64
pkg: github.com/loopholelabs/frisbee/internal/protocol
BenchmarkEncodeHandler-10               75458544                15.65 ns/op
BenchmarkDecodeHandler-10               100000000               11.83 ns/op
BenchmarkEncodeDecodeHandler-10         41504779                28.61 ns/op
BenchmarkEncode-10                      96262796                12.34 ns/op
BenchmarkDecode-10                      136256695                8.907 ns/op
BenchmarkEncodeDecode-10                47854282                24.35 ns/op
PASS
ok      github.com/loopholelabs/frisbee/internal/protocol       9.113s
PASS
ok      github.com/loopholelabs/frisbee/internal/ringbuffer     0.111s
```

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `go fmt ./...` has been run
- [x] `golangci-lint run --skip-dirs-use-default` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
