### PR TITLE
(Fix) ConnContext TLS Handshake

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 cli:
-  version: 0.7.0-beta
+  version: 0.8.0-beta
 lint:
   enabled:
     - gitleaks@7.6.1

--- a/async.go
+++ b/async.go
@@ -18,6 +18,7 @@ package frisbee
 
 import (
 	"bufio"
+	"context"
 	"crypto/tls"
 	"encoding/binary"
 	"github.com/loopholelabs/frisbee/pkg/metadata"
@@ -124,7 +125,25 @@ func (c *Async) ConnectionState() (tls.ConnectionState, error) {
 	if tlsConn, ok := c.conn.(*tls.Conn); ok {
 		return tlsConn.ConnectionState(), nil
 	}
-	return tls.ConnectionState{}, NotTLSConnectionError
+	return emptyState, NotTLSConnectionError
+}
+
+// Handshake performs the tls.Handshake() of a *tls.Conn
+// if the connection is not *tls.Conn then the NotTLSConnectionError is returned
+func (c *Async) Handshake() error {
+	if tlsConn, ok := c.conn.(*tls.Conn); ok {
+		return tlsConn.Handshake()
+	}
+	return NotTLSConnectionError
+}
+
+// HandshakeContext performs the tls.HandshakeContext() of a *tls.Conn
+// if the connection is not *tls.Conn then the NotTLSConnectionError is returned
+func (c *Async) HandshakeContext(ctx context.Context) error {
+	if tlsConn, ok := c.conn.(*tls.Conn); ok {
+		return tlsConn.HandshakeContext(ctx)
+	}
+	return NotTLSConnectionError
 }
 
 // LocalAddr returns the local address of the underlying net.Conn

--- a/async.go
+++ b/async.go
@@ -141,7 +141,7 @@ func (c *Async) Handshake() error {
 // if the connection is not *tls.Conn then the NotTLSConnectionError is returned
 func (c *Async) HandshakeContext(ctx context.Context) error {
 	if tlsConn, ok := c.conn.(*tls.Conn); ok {
-		return tlsConn.HandshakeContext(ctx)
+		return tlsConn.HandshakeContext(ctx) //trunk-ignore(golangci-lint/typecheck)
 	}
 	return NotTLSConnectionError
 }

--- a/async_test.go
+++ b/async_test.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -341,9 +342,11 @@ func TestAsyncTimeout(t *testing.T) {
 
 	_, err = readerConn.ReadPacket()
 	assert.ErrorIs(t, err, ConnectionClosed)
+
 	err = readerConn.Error()
 	if err == nil {
-		time.Sleep(defaultDeadline * 5)
+		runtime.Gosched()
+		time.Sleep(defaultDeadline * 10)
 	}
 	assert.Error(t, readerConn.Error())
 

--- a/conn.go
+++ b/conn.go
@@ -17,6 +17,7 @@
 package frisbee
 
 import (
+	"context"
 	"crypto/tls"
 	"github.com/loopholelabs/frisbee/pkg/packet"
 	"github.com/pkg/errors"
@@ -30,10 +31,14 @@ import (
 const DefaultBufferSize = 1 << 19
 
 var (
-	defaultLogger   = zerolog.New(os.Stdout)
+	defaultLogger = zerolog.New(os.Stdout)
+
 	defaultDeadline = time.Second
-	emptyTime       = time.Time{}
-	pastTime        = time.Unix(1, 0)
+
+	emptyTime = time.Time{}
+	pastTime  = time.Unix(1, 0)
+
+	emptyState = tls.ConnectionState{}
 )
 
 var (
@@ -45,6 +50,8 @@ type Conn interface {
 	LocalAddr() net.Addr
 	RemoteAddr() net.Addr
 	ConnectionState() (tls.ConnectionState, error)
+	Handshake() error
+	HandshakeContext(context.Context) error
 	SetDeadline(time.Time) error
 	SetReadDeadline(time.Time) error
 	SetWriteDeadline(time.Time) error

--- a/sync.go
+++ b/sync.go
@@ -17,6 +17,7 @@
 package frisbee
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/binary"
 	"github.com/loopholelabs/frisbee/pkg/metadata"
@@ -97,7 +98,25 @@ func (c *Sync) ConnectionState() (tls.ConnectionState, error) {
 	if tlsConn, ok := c.conn.(*tls.Conn); ok {
 		return tlsConn.ConnectionState(), nil
 	}
-	return tls.ConnectionState{}, NotTLSConnectionError
+	return emptyState, NotTLSConnectionError
+}
+
+// Handshake performs the tls.Handshake() of a *tls.Conn
+// if the connection is not *tls.Conn then the NotTLSConnectionError is returned
+func (c *Sync) Handshake() error {
+	if tlsConn, ok := c.conn.(*tls.Conn); ok {
+		return tlsConn.Handshake()
+	}
+	return NotTLSConnectionError
+}
+
+// HandshakeContext performs the tls.HandshakeContext() of a *tls.Conn
+// if the connection is not *tls.Conn then the NotTLSConnectionError is returned
+func (c *Sync) HandshakeContext(ctx context.Context) error {
+	if tlsConn, ok := c.conn.(*tls.Conn); ok {
+		return tlsConn.HandshakeContext(ctx)
+	}
+	return NotTLSConnectionError
 }
 
 // LocalAddr returns the local address of the underlying net.Conn

--- a/sync.go
+++ b/sync.go
@@ -114,7 +114,7 @@ func (c *Sync) Handshake() error {
 // if the connection is not *tls.Conn then the NotTLSConnectionError is returned
 func (c *Sync) HandshakeContext(ctx context.Context) error {
 	if tlsConn, ok := c.conn.(*tls.Conn); ok {
-		return tlsConn.HandshakeContext(ctx)
+		return tlsConn.HandshakeContext(ctx) //trunk-ignore(golangci-lint/typecheck)
 	}
 	return NotTLSConnectionError
 }


### PR DESCRIPTION
## Description

We've added two major functions to the frisbee.Conn interface:
- `Handshake`
- `HandshakeContext`

These allow for running the TLS handshake on an underlying TLS frisbee.Conn if it's required. Also changed where the connContext function was being run to generate a connection-specific contexts - guaranteed that the TLS Handshake would be complete and at least one packet would be read before the connection context was generated. 

Fixes [#13](https://app.zenhub.com/workspaces/loophole-labs-61d69c9aa0a1140011fbdff4/issues/loopholelabs/lynk/139)

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] Bug fix (non-breaking change which fixes an issue) [title: 'fix:']

## Testing

N/A

## Benchmarking

Frisbee tries to adhere to strict performance requirements, so please make sure to run `go test -bench=. ./...` and paste the results below:

### Benchmarking Results:

```shell
BenchmarkAsyncThroughputNetwork/1024_Bytes-10              33042             35922 ns/op        2850.64 MB/s         257 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/2048_Bytes-10              24004             49722 ns/op        4118.90 MB/s         258 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/4096_Bytes-10              17325             69900 ns/op        5859.80 MB/s         260 B/op          4 allocs/op
BenchmarkThroughputClient/test-10                             90          12694027 ns/op        2643.28 MB/s        8025 B/op         11 allocs/op
BenchmarkThroughputResponseClient/test-10                     85          14194973 ns/op        2363.79 MB/s        8091 B/op          4 allocs/op
BenchmarkThroughputServer/test-10                             90          14205831 ns/op        2361.98 MB/s        3337 B/op          3 allocs/op
BenchmarkThroughputResponseServer/test-10                    100          14062758 ns/op        2386.01 MB/s       11147 B/op         33 allocs/op
BenchmarkSyncThroughputPipe/32_Bytes-10                     8919            128523 ns/op          24.90 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/512_Bytes-10                    9290            129316 ns/op         395.93 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/1024_Bytes-10                   9123            129083 ns/op         793.29 MB/s        1859 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/2048_Bytes-10                   8918            131912 ns/op        1552.55 MB/s        1862 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/4096_Bytes-10                   8761            134174 ns/op        3052.75 MB/s        1865 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/32_Bytes-10                  3571            367589 ns/op           8.71 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/512_Bytes-10                 3195            364870 ns/op         140.32 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/1024_Bytes-10                3284            393648 ns/op         260.13 MB/s        1864 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/2048_Bytes-10                3056            364121 ns/op         562.45 MB/s        1866 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/4096_Bytes-10                2984            385427 ns/op        1062.72 MB/s        1885 B/op        204 allocs/op
BenchmarkAsyncThroughputLarge/1MB-10                         163           7298196 ns/op        14367.61 MB/s      65415 B/op          4 allocs/op
BenchmarkAsyncThroughputLarge/2MB-10                          81          15072136 ns/op        13914.10 MB/s     305679 B/op          5 allocs/op
BenchmarkAsyncThroughputLarge/4MB-10                          26          58318168 ns/op        7192.11 MB/s      857638 B/op          6 allocs/op
BenchmarkAsyncThroughputLarge/8MB-10                           9         118370204 ns/op        7086.76 MB/s     5714866 B/op         12 allocs/op
BenchmarkAsyncThroughputLarge/16MB-10                          5         244712258 ns/op        6855.90 MB/s    12113161 B/op         16 allocs/op
BenchmarkSyncThroughputLarge/1MB-10                           98          11971714 ns/op        8758.78 MB/s     2141621 B/op        217 allocs/op
BenchmarkSyncThroughputLarge/2MB-10                           49          23717975 ns/op        8842.04 MB/s     3676567 B/op        216 allocs/op
BenchmarkSyncThroughputLarge/4MB-10                           24          47276311 ns/op        8871.89 MB/s     4399881 B/op        212 allocs/op
BenchmarkSyncThroughputLarge/8MB-10                           10         104594400 ns/op        8020.13 MB/s    50047889 B/op        252 allocs/op
BenchmarkSyncThroughputLarge/16MB-10                           5         228074425 ns/op        7356.03 MB/s    102638984 B/op       248 allocs/op
BenchmarkTCPThroughput/32_Bytes-10                         22554             53009 ns/op          60.37 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/512_Bytes-10                        14184             84403 ns/op         606.61 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/1024_Bytes-10                        9496            124797 ns/op         820.54 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/2048_Bytes-10                        5754            211609 ns/op         967.82 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/4096_Bytes-10                        3055            390492 ns/op        1048.93 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/1MB-10                                 92          12458045 ns/op        8416.86 MB/s         308 B/op          4 allocs/op
BenchmarkTCPThroughput/2MB-10                                 43          24560609 ns/op        8538.68 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/4MB-10                                 26          49134827 ns/op        8536.32 MB/s         320 B/op          4 allocs/op
BenchmarkTCPThroughput/8MB-10                                 10         103506192 ns/op        8104.45 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/16MB-10                                 5         228259967 ns/op        7350.05 MB/s         304 B/op          4 allocs/op
PASS
ok      github.com/loopholelabs/frisbee 89.848s
goos: darwin
goarch: arm64
pkg: github.com/loopholelabs/frisbee/pkg/metadata
BenchmarkEncodeHandler-10               199355238                5.932 ns/op
BenchmarkDecodeHandler-10               246175096                4.871 ns/op
BenchmarkEncodeDecodeHandler-10         96220668                13.40 ns/op
BenchmarkEncode-10                      223625019                5.408 ns/op
BenchmarkDecode-10                      307439752                3.885 ns/op
BenchmarkEncodeDecode-10                100000000               11.31 ns/op
PASS
ok      github.com/loopholelabs/frisbee/pkg/metadata    9.426s
PASS
ok      github.com/loopholelabs/frisbee/pkg/packet      0.100s
PASS
ok      github.com/loopholelabs/frisbee/pkg/queue       0.077s
```

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `trunk check` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
