### PR TITLE
(feat) Packet Content is Writable

### DIFF
--- a/async_test.go
+++ b/async_test.go
@@ -57,12 +57,12 @@ func TestNewAsync(t *testing.T) {
 	assert.Equal(t, uint16(64), p.Metadata.Id)
 	assert.Equal(t, uint16(32), p.Metadata.Operation)
 	assert.Equal(t, uint32(0), p.Metadata.ContentLength)
-	assert.Equal(t, 0, len(p.Content))
+	assert.Equal(t, 0, p.Content.Len())
 
 	data := make([]byte, packetSize)
 	_, _ = rand.Read(data)
 
-	p.Write(data)
+	p.Content.Write(data)
 	p.Metadata.ContentLength = packetSize
 
 	err = writerConn.WritePacket(p)
@@ -76,8 +76,8 @@ func TestNewAsync(t *testing.T) {
 	assert.Equal(t, uint16(64), p.Metadata.Id)
 	assert.Equal(t, uint16(32), p.Metadata.Operation)
 	assert.Equal(t, uint32(packetSize), p.Metadata.ContentLength)
-	assert.Equal(t, len(data), len(p.Content))
-	assert.Equal(t, data, p.Content)
+	assert.Equal(t, len(data), p.Content.Len())
+	assert.Equal(t, data, p.Content.B)
 
 	packet.Put(p)
 
@@ -109,8 +109,9 @@ func TestAsyncLargeWrite(t *testing.T) {
 	for i := 0; i < testSize; i++ {
 		randomData[i] = make([]byte, packetSize)
 		_, _ = rand.Read(randomData[i])
-		p.Write(randomData[i])
+		p.Content.Write(randomData[i])
 		err := writerConn.WritePacket(p)
+		p.Content.Reset()
 		assert.NoError(t, err)
 	}
 	packet.Put(p)
@@ -122,8 +123,8 @@ func TestAsyncLargeWrite(t *testing.T) {
 		assert.Equal(t, uint16(64), p.Metadata.Id)
 		assert.Equal(t, uint16(32), p.Metadata.Operation)
 		assert.Equal(t, uint32(packetSize), p.Metadata.ContentLength)
-		assert.Equal(t, len(randomData[i]), len(p.Content))
-		assert.Equal(t, randomData[i], p.Content)
+		assert.Equal(t, len(randomData[i]), p.Content.Len())
+		assert.Equal(t, randomData[i], p.Content.B)
 		packet.Put(p)
 	}
 
@@ -153,7 +154,7 @@ func TestAsyncRawConn(t *testing.T) {
 	p := packet.Get()
 	p.Metadata.Id = 64
 	p.Metadata.Operation = 32
-	p.Write(randomData)
+	p.Content.Write(randomData)
 	p.Metadata.ContentLength = packetSize
 
 	for i := 0; i < testSize; i++ {
@@ -170,8 +171,8 @@ func TestAsyncRawConn(t *testing.T) {
 		assert.Equal(t, uint16(64), p.Metadata.Id)
 		assert.Equal(t, uint16(32), p.Metadata.Operation)
 		assert.Equal(t, uint32(packetSize), p.Metadata.ContentLength)
-		assert.Equal(t, len(randomData), len(p.Content))
-		assert.Equal(t, randomData, p.Content)
+		assert.Equal(t, packetSize, p.Content.Len())
+		assert.Equal(t, randomData, p.Content.B)
 	}
 
 	rawReaderConn := readerConn.Raw()
@@ -224,7 +225,7 @@ func TestAsyncReadClose(t *testing.T) {
 	assert.Equal(t, uint16(64), p.Metadata.Id)
 	assert.Equal(t, uint16(32), p.Metadata.Operation)
 	assert.Equal(t, uint32(0), p.Metadata.ContentLength)
-	assert.Equal(t, 0, len(p.Content))
+	assert.Equal(t, 0, p.Content.Len())
 
 	err = readerConn.conn.Close()
 	assert.NoError(t, err)
@@ -272,7 +273,7 @@ func TestAsyncWriteClose(t *testing.T) {
 	assert.Equal(t, uint16(64), p.Metadata.Id)
 	assert.Equal(t, uint16(32), p.Metadata.Operation)
 	assert.Equal(t, uint32(0), p.Metadata.ContentLength)
-	assert.Equal(t, 0, len(p.Content))
+	assert.Equal(t, 0, p.Content.Len())
 
 	err = writerConn.WritePacket(p)
 	assert.NoError(t, err)
@@ -323,7 +324,7 @@ func TestAsyncTimeout(t *testing.T) {
 	assert.Equal(t, uint16(64), p.Metadata.Id)
 	assert.Equal(t, uint16(32), p.Metadata.Operation)
 	assert.Equal(t, uint32(0), p.Metadata.ContentLength)
-	assert.Equal(t, 0, len(p.Content))
+	assert.Equal(t, 0, p.Content.Len())
 
 	time.Sleep(defaultDeadline * 5)
 

--- a/client.go
+++ b/client.go
@@ -167,7 +167,7 @@ func (c *Client) handlePacket(ctx context.Context, conn *Async, p *packet.Packet
 			packetCtx = c.PacketContext(packetCtx, p)
 		}
 		outgoing, action := handlerFunc(packetCtx, p)
-		if outgoing != nil && outgoing.Metadata.ContentLength == uint32(len(outgoing.Content)) {
+		if outgoing != nil && outgoing.Metadata.ContentLength == uint32(outgoing.Content.Len()) {
 			err := conn.WritePacket(outgoing)
 			if outgoing != p {
 				packet.Put(outgoing)

--- a/client_test.go
+++ b/client_test.go
@@ -86,7 +86,7 @@ func TestClientRaw(t *testing.T) {
 
 	p := packet.Get()
 	p.Metadata.Operation = metadata.PacketPing
-	p.Write(data)
+	p.Content.Write(data)
 	p.Metadata.ContentLength = packetSize
 
 	for q := 0; q < testSize; q++ {
@@ -169,7 +169,7 @@ func BenchmarkThroughputClient(b *testing.B) {
 	p := packet.Get()
 
 	p.Metadata.Operation = metadata.PacketPing
-	p.Write(data)
+	p.Content.Write(data)
 	p.Metadata.ContentLength = packetSize
 
 	b.Run("test", func(b *testing.B) {
@@ -250,7 +250,7 @@ func BenchmarkThroughputResponseClient(b *testing.B) {
 	p := packet.Get()
 	p.Metadata.Operation = metadata.PacketPing
 
-	p.Write(data)
+	p.Content.Write(data)
 	p.Metadata.ContentLength = packetSize
 
 	b.Run("test", func(b *testing.B) {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -37,7 +37,7 @@ func throughputRunner(testSize uint32, packetSize uint32, readerConn Conn, write
 		p := packet.Get()
 		p.Metadata.Id = 64
 		p.Metadata.Operation = 32
-		p.Write(randomData)
+		p.Content.Write(randomData)
 		p.Metadata.ContentLength = packetSize
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/pkg/packet/content.go
+++ b/pkg/packet/content.go
@@ -1,0 +1,66 @@
+/*
+	Copyright 2022 Loophole Labs
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		   http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package packet
+
+const (
+	defaultSize = 512
+)
+
+// Content is a packet's byte buffer that grows and is recycled as required
+type Content struct {
+	B []byte
+}
+
+// NewContent returns a new Content struct with an allocated array of size defaultSize
+func NewContent() *Content {
+	return &Content{
+		B: make([]byte, 0, defaultSize),
+	}
+}
+
+// Reset resets the underlying byte slice for future use
+func (c *Content) Reset() {
+	c.B = c.B[:0]
+}
+
+// Write efficiently copies the byte slice b into the content buffer, however it
+// does *not* update the content length.
+func (c *Content) Write(b []byte) int {
+	if c.B == nil {
+		c.B = make([]byte, len(b))
+		copy(c.B, b)
+	} else if cap(c.B)-len(c.B) < len(b) {
+		c.B = append(c.B[:len(c.B)], b...)
+	} else {
+		c.B = c.B[:len(c.B)+copy(c.B[len(c.B):cap(c.B)], b)]
+	}
+	return len(b)
+}
+
+func (c *Content) Len() int {
+	if c == nil {
+		return 0
+	}
+	return len(c.B)
+}
+
+func (c *Content) Cap() int {
+	if c == nil {
+		return 0
+	}
+	return cap(c.B)
+}

--- a/pkg/packet/packet.go
+++ b/pkg/packet/packet.go
@@ -35,27 +35,12 @@ import (
 // delivered with the frisbee packet (see the Async.WritePacket function for more details), and the Operation field must be greater than uint16(9).
 type Packet struct {
 	Metadata *metadata.Metadata
-	Content  []byte
-}
-
-// Write efficiently copies the byte slice b into the packet, however it
-// does *not* update the content length.
-func (p *Packet) Write(b []byte) int {
-	if p.Content == nil {
-		p.Content = make([]byte, len(b))
-		copy(p.Content, b)
-	} else if cap(p.Content) < len(b) {
-		p.Content = append(p.Content[:0], b...)
-		p.Content = p.Content[:len(b)]
-	} else {
-		p.Content = p.Content[:copy(p.Content[0:cap(p.Content)], b)]
-	}
-	return len(b)
+	Content  *Content
 }
 
 func (p *Packet) Reset() {
 	p.Metadata.Id = 0
 	p.Metadata.Operation = 0
 	p.Metadata.ContentLength = 0
-	p.Content = p.Content[:0]
+	p.Content.Reset()
 }

--- a/pkg/packet/pool.go
+++ b/pkg/packet/pool.go
@@ -38,7 +38,7 @@ func (p *Pool) Get() (s *Packet) {
 	if v == nil {
 		s = &Packet{
 			Metadata: new(metadata.Metadata),
-			Content:  make([]byte, 0, 512),
+			Content:  NewContent(),
 		}
 		return
 	}

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -60,7 +60,7 @@ func TestQueue(t *testing.T) {
 	}
 	testPacket2 := func() *packet.Packet {
 		p := packet.Get()
-		p.Content = []byte{1}
+		p.Content.Write([]byte{1})
 		return p
 	}
 

--- a/server.go
+++ b/server.go
@@ -160,7 +160,7 @@ func (s *Server) handlePacket(p *packet.Packet, connCtx context.Context, conn *A
 			packetCtx = s.PacketContext(packetCtx, p)
 		}
 		outgoing, action := handlerFunc(packetCtx, p)
-		if outgoing != nil && outgoing.Metadata.ContentLength == uint32(len(outgoing.Content)) {
+		if outgoing != nil && outgoing.Metadata.ContentLength == uint32(outgoing.Content.Len()) {
 			s.PreWrite()
 			err := conn.WritePacket(outgoing)
 			if outgoing != p {

--- a/server_test.go
+++ b/server_test.go
@@ -84,10 +84,10 @@ func TestServerRaw(t *testing.T) {
 	data := make([]byte, packetSize)
 	_, _ = rand.Read(data)
 	p := packet.Get()
-	p.Write(data)
+	p.Content.Write(data)
 	p.Metadata.ContentLength = packetSize
 	p.Metadata.Operation = metadata.PacketPing
-	assert.Equal(t, data, p.Content)
+	assert.Equal(t, data, p.Content.B)
 
 	for q := 0; q < testSize; q++ {
 		p.Metadata.Id = uint16(q)
@@ -96,7 +96,7 @@ func TestServerRaw(t *testing.T) {
 	}
 
 	p.Reset()
-	assert.Equal(t, 0, len(p.Content))
+	assert.Equal(t, 0, p.Content.Len())
 	p.Metadata.Operation = metadata.PacketProbe
 
 	err = c.WritePacket(p)
@@ -164,7 +164,7 @@ func BenchmarkThroughputServer(b *testing.B) {
 	p := packet.Get()
 	p.Metadata.Operation = metadata.PacketPing
 
-	p.Write(data)
+	p.Content.Write(data)
 	p.Metadata.ContentLength = packetSize
 
 	b.Run("test", func(b *testing.B) {
@@ -233,7 +233,7 @@ func BenchmarkThroughputResponseServer(b *testing.B) {
 	p := packet.Get()
 	p.Metadata.Operation = metadata.PacketPing
 
-	p.Write(data)
+	p.Content.Write(data)
 	p.Metadata.ContentLength = packetSize
 
 	b.Run("test", func(b *testing.B) {

--- a/sync_test.go
+++ b/sync_test.go
@@ -55,7 +55,7 @@ func TestNewSync(t *testing.T) {
 		assert.Equal(t, uint16(64), p.Metadata.Id)
 		assert.Equal(t, uint16(32), p.Metadata.Operation)
 		assert.Equal(t, uint32(0), p.Metadata.ContentLength)
-		assert.Equal(t, 0, len(p.Content))
+		assert.Equal(t, 0, p.Content.Len())
 		end <- struct{}{}
 		packet.Put(p)
 	}()
@@ -68,7 +68,7 @@ func TestNewSync(t *testing.T) {
 	data := make([]byte, packetSize)
 	_, _ = rand.Read(data)
 
-	p.Write(data)
+	p.Content.Write(data)
 	p.Metadata.ContentLength = packetSize
 
 	go func() {
@@ -79,8 +79,8 @@ func TestNewSync(t *testing.T) {
 		assert.Equal(t, uint16(64), p.Metadata.Id)
 		assert.Equal(t, uint16(32), p.Metadata.Operation)
 		assert.Equal(t, uint32(packetSize), p.Metadata.ContentLength)
-		assert.Equal(t, packetSize, len(p.Content))
-		assert.Equal(t, data, p.Content)
+		assert.Equal(t, packetSize, p.Content.Len())
+		assert.Equal(t, data, p.Content.B)
 		end <- struct{}{}
 		packet.Put(p)
 	}()
@@ -130,8 +130,8 @@ func TestSyncLargeWrite(t *testing.T) {
 			assert.Equal(t, uint16(64), p.Metadata.Id)
 			assert.Equal(t, uint16(32), p.Metadata.Operation)
 			assert.Equal(t, uint32(packetSize), p.Metadata.ContentLength)
-			assert.Equal(t, packetSize, len(p.Content))
-			assert.Equal(t, randomData[i], p.Content)
+			assert.Equal(t, packetSize, p.Content.Len())
+			assert.Equal(t, randomData[i], p.Content.B)
 			packet.Put(p)
 		}
 		end <- struct{}{}
@@ -141,8 +141,9 @@ func TestSyncLargeWrite(t *testing.T) {
 	for i := 0; i < testSize; i++ {
 		randomData[i] = make([]byte, packetSize)
 		_, _ = rand.Read(randomData[i])
-		p.Write(randomData[i])
+		p.Content.Write(randomData[i])
 		err := writerConn.WritePacket(p)
+		p.Content.Reset()
 		assert.NoError(t, err)
 	}
 	<-end
@@ -178,7 +179,7 @@ func TestSyncRawConn(t *testing.T) {
 	p := packet.Get()
 	p.Metadata.Id = 64
 	p.Metadata.Operation = 32
-	p.Write(randomData)
+	p.Content.Write(randomData)
 	p.Metadata.ContentLength = packetSize
 
 	go func() {
@@ -190,8 +191,8 @@ func TestSyncRawConn(t *testing.T) {
 			assert.Equal(t, uint16(64), p.Metadata.Id)
 			assert.Equal(t, uint16(32), p.Metadata.Operation)
 			assert.Equal(t, uint32(packetSize), p.Metadata.ContentLength)
-			assert.Equal(t, packetSize, len(p.Content))
-			assert.Equal(t, randomData, p.Content)
+			assert.Equal(t, packetSize, p.Content.Len())
+			assert.Equal(t, randomData, p.Content.B)
 			packet.Put(p)
 		}
 		end <- struct{}{}
@@ -254,7 +255,7 @@ func TestSyncReadClose(t *testing.T) {
 		assert.Equal(t, uint16(64), p.Metadata.Id)
 		assert.Equal(t, uint16(32), p.Metadata.Operation)
 		assert.Equal(t, uint32(0), p.Metadata.ContentLength)
-		assert.Equal(t, 0, len(p.Content))
+		assert.Equal(t, 0, p.Content.Len())
 		end <- struct{}{}
 		packet.Put(p)
 	}()
@@ -304,7 +305,7 @@ func TestSyncWriteClose(t *testing.T) {
 		assert.Equal(t, uint16(64), p.Metadata.Id)
 		assert.Equal(t, uint16(32), p.Metadata.Operation)
 		assert.Equal(t, uint32(0), p.Metadata.ContentLength)
-		assert.Equal(t, 0, len(p.Content))
+		assert.Equal(t, 0, p.Content.Len())
 		packet.Put(p)
 		end <- struct{}{}
 	}()


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue has been fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #67 

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] New feature (non-breaking change which adds functionality) [title: 'feat:']
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Testing

Please make sure that existing test cases pass (with `go test ./... -race` and `go test -bench=. ./... -race`),
and if required please add new test cases and list them below:

- [x] TestWrite

## Benchmarking

Frisbee tries to adhere to strict performance requirements, so please make sure to run `go test -bench=. ./...` and paste the results below:

### Benchmarking Results:

```shell
goos: darwin
goarch: arm64
pkg: github.com/loopholelabs/frisbee
BenchmarkAsyncThroughputPipe/32_Bytes-10                  127966              9602 ns/op         333.26 MB/s         448 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/512_Bytes-10                  74445             16049 ns/op        3190.14 MB/s         449 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/1024_Bytes-10                 61855             19377 ns/op        5284.51 MB/s         452 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/2048_Bytes-10                 43914             27275 ns/op        7508.78 MB/s         459 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/4096_Bytes-10                 27034             44225 ns/op        9261.68 MB/s         473 B/op          8 allocs/op
BenchmarkAsyncThroughputNetwork/32_Bytes-10                46742             24390 ns/op         131.20 MB/s         256 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/512_Bytes-10               39758             29880 ns/op        1713.51 MB/s         257 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/1024_Bytes-10              32635             36505 ns/op        2805.10 MB/s         257 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/2048_Bytes-10              23928             50041 ns/op        4092.65 MB/s         258 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/4096_Bytes-10              17035             70403 ns/op        5817.95 MB/s         260 B/op          4 allocs/op
BenchmarkThroughputClient/test-10                             79          13841876 ns/op        2424.09 MB/s       11738 B/op         29 allocs/op
BenchmarkThroughputResponseClient/test-10                     82          14158279 ns/op        2369.92 MB/s       16428 B/op         62 allocs/op
BenchmarkThroughputServer/test-10                            100          14155481 ns/op        2370.38 MB/s        3360 B/op         14 allocs/op
BenchmarkThroughputResponseServer/test-10                     87          14305466 ns/op        2345.53 MB/s       11936 B/op         42 allocs/op
BenchmarkSyncThroughputPipe/32_Bytes-10                     8937            129279 ns/op          24.75 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/512_Bytes-10                    9164            129153 ns/op         396.43 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/1024_Bytes-10                   9116            130350 ns/op         785.57 MB/s        1859 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/2048_Bytes-10                   8751            132833 ns/op        1541.78 MB/s        1861 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/4096_Bytes-10                   8954            134794 ns/op        3038.72 MB/s        1873 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/32_Bytes-10                  3448            346604 ns/op           9.23 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/512_Bytes-10                 3220            366838 ns/op         139.57 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/1024_Bytes-10                2941            383860 ns/op         266.76 MB/s        1859 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/2048_Bytes-10                2924            391302 ns/op         523.38 MB/s        1862 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/4096_Bytes-10                2936            405615 ns/op        1009.83 MB/s        1873 B/op        204 allocs/op
BenchmarkAsyncThroughputLarge/1MB-10                         166           7375143 ns/op        14217.70 MB/s      64781 B/op          4 allocs/op
BenchmarkAsyncThroughputLarge/2MB-10                          85          13906230 ns/op        15080.67 MB/s     320324 B/op          5 allocs/op
BenchmarkAsyncThroughputLarge/4MB-10                          25          56547628 ns/op        7417.29 MB/s     1095767 B/op          7 allocs/op
BenchmarkAsyncThroughputLarge/8MB-10                           9         120251931 ns/op        6975.86 MB/s     7485360 B/op         14 allocs/op
BenchmarkAsyncThroughputLarge/16MB-10                          5         246160500 ns/op        6815.56 MB/s    34452043 B/op         26 allocs/op
BenchmarkSyncThroughputLarge/1MB-10                           98          12283571 ns/op        8536.41 MB/s      857761 B/op        209 allocs/op
BenchmarkSyncThroughputLarge/2MB-10                           48          24273362 ns/op        8639.73 MB/s     2208515 B/op        211 allocs/op
BenchmarkSyncThroughputLarge/4MB-10                           24          49218715 ns/op        8521.77 MB/s     9677472 B/op        221 allocs/op
BenchmarkSyncThroughputLarge/8MB-10                           12         103694455 ns/op        8089.74 MB/s    10428225 B/op        215 allocs/op
BenchmarkSyncThroughputLarge/16MB-10                           5         240649042 ns/op        6971.65 MB/s    164221270 B/op       276 allocs/op
BenchmarkTCPThroughput/32_Bytes-10                         22507             53414 ns/op          59.91 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/512_Bytes-10                        13803             86869 ns/op         589.39 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/1024_Bytes-10                        9424            127853 ns/op         800.92 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/2048_Bytes-10                        5456            214814 ns/op         953.38 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/4096_Bytes-10                        3021            400671 ns/op        1022.28 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/1MB-10                                100          12716947 ns/op        8245.50 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/2MB-10                                 48          24509158 ns/op        8556.61 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/4MB-10                                 22          49270814 ns/op        8512.76 MB/s         322 B/op          4 allocs/op
BenchmarkTCPThroughput/8MB-10                                 10         106323329 ns/op        7889.72 MB/s         345 B/op          4 allocs/op
BenchmarkTCPThroughput/16MB-10                                 5         223398175 ns/op        7510.01 MB/s         304 B/op          4 allocs/op
PASS
ok      github.com/loopholelabs/frisbee 87.295s
goos: darwin
goarch: arm64
pkg: github.com/loopholelabs/frisbee/pkg/metadata
BenchmarkEncodeHandler-10               202053721                5.876 ns/op
BenchmarkDecodeHandler-10               251702883                4.746 ns/op
BenchmarkEncodeDecodeHandler-10         83419260                13.94 ns/op
BenchmarkEncode-10                      225890200                5.314 ns/op
BenchmarkDecode-10                      314946542                3.819 ns/op
BenchmarkEncodeDecode-10                100000000               11.33 ns/op
PASS
ok      github.com/loopholelabs/frisbee/pkg/metadata    9.257s
PASS
ok      github.com/loopholelabs/frisbee/pkg/packet      0.102s
PASS
ok      github.com/loopholelabs/frisbee/pkg/queue       0.079s
```

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `trunk check` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
