### PR TITLE
Fix: #70, Reads after Connection close should only error when there is no more available data

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 cli:
-  version: 0.8.0-beta
+  version: 0.8.1-beta
 lint:
   enabled:
     - gitleaks@7.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixes
+
+- Closing a connection doesn't mean the other side loses data it hasn't reacted to yet
+
+### Changes
+
+- A `Drain` function was added to the `internal/queue` package to allow the `killGoroutines` function in `async.go` to
+  drain the queue once it had closed it and once it had killed all existing goroutines
+- The `heartbeat` function in `client.go` was modified to exit early if it detected that the underlying connection had
+  closed
+- The `async` connection type was modified to hold `stale` data once a connection is closed. The `killGoroutines`
+  function will drain the `incoming` queue after killing all goroutines, and store those drained packets in
+  the `async.stale` variable - future and existing ReadPacket calls will first check whether there is data available in
+  the `stale` variable before they error out
+- Refactored the `handlePacket` functions for both servers and clients to be clearer and avoid allocations
+- The `close` function call in `Async` connections was modified to set a final write deadline for its final writer flush
+
 ## [v0.2.1] - 2022-03-02 (Beta)
 
 ### Fixes

--- a/async_test.go
+++ b/async_test.go
@@ -245,6 +245,56 @@ func TestAsyncReadClose(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestAsyncReadAvailableClose(t *testing.T) {
+	t.Parallel()
+
+	reader, writer := net.Pipe()
+
+	emptyLogger := zerolog.New(ioutil.Discard)
+
+	readerConn := NewAsync(reader, &emptyLogger, false)
+	writerConn := NewAsync(writer, &emptyLogger, false)
+
+	p := packet.Get()
+	p.Metadata.Id = 64
+	p.Metadata.Operation = 32
+
+	err := writerConn.WritePacket(p)
+	require.NoError(t, err)
+
+	err = writerConn.WritePacket(p)
+	require.NoError(t, err)
+
+	packet.Put(p)
+
+	err = writerConn.Close()
+	require.NoError(t, err)
+
+	p, err = readerConn.ReadPacket()
+	require.NoError(t, err)
+	assert.NotNil(t, p.Metadata)
+	assert.Equal(t, uint16(64), p.Metadata.Id)
+	assert.Equal(t, uint16(32), p.Metadata.Operation)
+	assert.Equal(t, uint32(0), p.Metadata.ContentLength)
+	assert.Equal(t, 0, len(p.Content.B))
+
+	p, err = readerConn.ReadPacket()
+	require.NoError(t, err)
+	assert.NotNil(t, p.Metadata)
+	assert.Equal(t, uint16(64), p.Metadata.Id)
+	assert.Equal(t, uint16(32), p.Metadata.Operation)
+	assert.Equal(t, uint32(0), p.Metadata.ContentLength)
+	assert.Equal(t, 0, len(p.Content.B))
+
+	p, err = readerConn.ReadPacket()
+	require.Error(t, err)
+
+	err = readerConn.Close()
+	assert.NoError(t, err)
+	err = writerConn.Close()
+	assert.NoError(t, err)
+}
+
 func TestAsyncWriteClose(t *testing.T) {
 	t.Parallel()
 

--- a/async_test.go
+++ b/async_test.go
@@ -221,7 +221,7 @@ func TestAsyncReadClose(t *testing.T) {
 
 	p, err = readerConn.ReadPacket()
 	require.NoError(t, err)
-	assert.NotNil(t, p.Metadata)
+	require.NotNil(t, p.Metadata)
 	assert.Equal(t, uint16(64), p.Metadata.Id)
 	assert.Equal(t, uint16(32), p.Metadata.Operation)
 	assert.Equal(t, uint32(0), p.Metadata.ContentLength)
@@ -272,7 +272,7 @@ func TestAsyncReadAvailableClose(t *testing.T) {
 
 	p, err = readerConn.ReadPacket()
 	require.NoError(t, err)
-	assert.NotNil(t, p.Metadata)
+	require.NotNil(t, p.Metadata)
 	assert.Equal(t, uint16(64), p.Metadata.Id)
 	assert.Equal(t, uint16(32), p.Metadata.Operation)
 	assert.Equal(t, uint32(0), p.Metadata.ContentLength)
@@ -280,7 +280,7 @@ func TestAsyncReadAvailableClose(t *testing.T) {
 
 	p, err = readerConn.ReadPacket()
 	require.NoError(t, err)
-	assert.NotNil(t, p.Metadata)
+	require.NotNil(t, p.Metadata)
 	assert.Equal(t, uint16(64), p.Metadata.Id)
 	assert.Equal(t, uint16(32), p.Metadata.Operation)
 	assert.Equal(t, uint32(0), p.Metadata.ContentLength)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/loopholelabs/frisbee
 go 1.15
 
 require (
-	github.com/loopholelabs/packet v0.2.0
+	github.com/loopholelabs/packet v0.2.2
 	github.com/loopholelabs/testing v0.2.3
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/loopholelabs/packet v0.2.0 h1:Ky3uFP0Wd6uspoWgQs9Iv/hIJCJOQ3bxK2c1lI8iFlo=
-github.com/loopholelabs/packet v0.2.0/go.mod h1:Hum5UcvYmf7yzALFmavDBoKKcKnV24GlZNNxJdaCSHo=
+github.com/loopholelabs/packet v0.2.2 h1:LAHMKGviIEO9HB8+M0v7EfeT4G5trWb5eclslhjuXlg=
+github.com/loopholelabs/packet v0.2.2/go.mod h1:Hum5UcvYmf7yzALFmavDBoKKcKnV24GlZNNxJdaCSHo=
 github.com/loopholelabs/testing v0.2.3 h1:4nVuK5ctaE6ua5Z0dYk2l7xTFmcpCYLUeGjRBp8keOA=
 github.com/loopholelabs/testing v0.2.3/go.mod h1:gqtGY91soYD1fQoKQt/6kP14OYpS7gcbcIgq5mc9m8Q=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/server.go
+++ b/server.go
@@ -152,43 +152,6 @@ func (s *Server) connCloser(conn *Async) {
 	}
 }
 
-func (s *Server) handlePacket(p *packet.Packet, connCtx context.Context, conn *Async) {
-	handlerFunc := s.handlerTable[p.Metadata.Operation]
-	if handlerFunc != nil {
-		packetCtx := connCtx
-		if s.PacketContext != nil {
-			packetCtx = s.PacketContext(packetCtx, p)
-		}
-		outgoing, action := handlerFunc(packetCtx, p)
-		if outgoing != nil && outgoing.Metadata.ContentLength == uint32(len(outgoing.Content.B)) {
-			s.PreWrite()
-			err := conn.WritePacket(outgoing)
-			if outgoing != p {
-				packet.Put(outgoing)
-			}
-			packet.Put(p)
-			if err != nil {
-				_ = conn.Close()
-				s.OnClosed(conn, err)
-				s.wg.Done()
-				return
-			}
-		} else {
-			packet.Put(p)
-		}
-		switch action {
-		case NONE:
-		case CLOSE:
-			_ = conn.Close()
-			s.OnClosed(conn, nil)
-			s.wg.Done()
-			return
-		}
-	} else {
-		packet.Put(p)
-	}
-}
-
 func (s *Server) handleConn(newConn net.Conn) {
 	var err error
 	switch v := newConn.(type) {
@@ -217,6 +180,8 @@ func (s *Server) handleConn(newConn net.Conn) {
 	connCtx := s.BaseContext()
 
 	var p *packet.Packet
+	var outgoing *packet.Packet
+	var action Action
 	p, err = frisbeeConn.ReadPacket()
 	if err != nil {
 		_ = frisbeeConn.Close()
@@ -227,7 +192,7 @@ func (s *Server) handleConn(newConn net.Conn) {
 	if s.ConnContext != nil {
 		connCtx = s.ConnContext(connCtx, frisbeeConn)
 	}
-	s.handlePacket(p, connCtx, frisbeeConn)
+	goto HANDLE
 LOOP:
 	p, err = frisbeeConn.ReadPacket()
 	if err != nil {
@@ -236,7 +201,41 @@ LOOP:
 		s.wg.Done()
 		return
 	}
-	s.handlePacket(p, connCtx, frisbeeConn)
+HANDLE:
+	handlerFunc := s.handlerTable[p.Metadata.Operation]
+	if handlerFunc != nil {
+		packetCtx := connCtx
+		if s.PacketContext != nil {
+			packetCtx = s.PacketContext(packetCtx, p)
+		}
+		outgoing, action = handlerFunc(packetCtx, p)
+		if outgoing != nil && outgoing.Metadata.ContentLength == uint32(len(outgoing.Content.B)) {
+			s.PreWrite()
+			err = frisbeeConn.WritePacket(outgoing)
+			if outgoing != p {
+				packet.Put(outgoing)
+			}
+			packet.Put(p)
+			if err != nil {
+				_ = frisbeeConn.Close()
+				s.OnClosed(frisbeeConn, err)
+				s.wg.Done()
+				return
+			}
+		} else {
+			packet.Put(p)
+		}
+		switch action {
+		case NONE:
+		case CLOSE:
+			_ = frisbeeConn.Close()
+			s.OnClosed(frisbeeConn, nil)
+			s.wg.Done()
+			return
+		}
+	} else {
+		packet.Put(p)
+	}
 	goto LOOP
 }
 

--- a/server.go
+++ b/server.go
@@ -182,6 +182,7 @@ func (s *Server) handleConn(newConn net.Conn) {
 	var p *packet.Packet
 	var outgoing *packet.Packet
 	var action Action
+	var handlerFunc Handler
 	p, err = frisbeeConn.ReadPacket()
 	if err != nil {
 		_ = frisbeeConn.Close()
@@ -202,7 +203,7 @@ LOOP:
 		return
 	}
 HANDLE:
-	handlerFunc := s.handlerTable[p.Metadata.Operation]
+	handlerFunc = s.handlerTable[p.Metadata.Operation]
 	if handlerFunc != nil {
 		packetCtx := connCtx
 		if s.PacketContext != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -133,6 +133,70 @@ func TestServerRaw(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestServerStaleClose(t *testing.T) {
+	t.Parallel()
+
+	const testSize = 100
+	const packetSize = 512
+	clientHandlerTable := make(HandlerTable)
+	serverHandlerTable := make(HandlerTable)
+
+	finished := make(chan struct{}, 1)
+
+	serverHandlerTable[metadata.PacketPing] = func(_ context.Context, incoming *packet.Packet) (outgoing *packet.Packet, action Action) {
+		if incoming.Metadata.Id == testSize-1 {
+			outgoing = incoming
+			action = CLOSE
+		}
+		return
+	}
+
+	clientHandlerTable[metadata.PacketPing] = func(_ context.Context, _ *packet.Packet) (outgoing *packet.Packet, action Action) {
+		finished <- struct{}{}
+		return
+	}
+
+	emptyLogger := zerolog.New(ioutil.Discard)
+	s, err := NewServer(":0", serverHandlerTable, WithLogger(&emptyLogger))
+	require.NoError(t, err)
+
+	err = s.Start()
+	require.NoError(t, err)
+
+	c, err := NewClient(s.listener.Addr().String(), clientHandlerTable, context.Background(), WithLogger(&emptyLogger))
+	assert.NoError(t, err)
+	_, err = c.Raw()
+	assert.ErrorIs(t, ConnectionNotInitialized, err)
+
+	err = c.Connect()
+	require.NoError(t, err)
+
+	data := make([]byte, packetSize)
+	_, _ = rand.Read(data)
+	p := packet.Get()
+	p.Content.Write(data)
+	p.Metadata.ContentLength = packetSize
+	p.Metadata.Operation = metadata.PacketPing
+	assert.Equal(t, data, p.Content.B)
+
+	for q := 0; q < testSize; q++ {
+		p.Metadata.Id = uint16(q)
+		err = c.WritePacket(p)
+		assert.NoError(t, err)
+	}
+	packet.Put(p)
+	<-finished
+
+	_, err = c.conn.ReadPacket()
+	assert.ErrorIs(t, err, ConnectionClosed)
+
+	err = c.Close()
+	assert.NoError(t, err)
+
+	err = s.Shutdown()
+	assert.NoError(t, err)
+}
+
 func BenchmarkThroughputServer(b *testing.B) {
 	const testSize = 1<<16 - 1
 	const packetSize = 512


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue has been fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- A `Drain` function was added to `internal/queue` to allow the `killGoroutines` function to drain the queue once it had closed it and once it had killed all existing goroutines
- The client `heartbeat` function was modified to exit early if it detected that the underlying connection had closed
- The `Async` connection type was modified to hold `stale` data once a connection is closed. The `killGoroutines` function will drain the `incoming` queue after killing all goroutines, and store those drained packets in the `Async.stale` variable - future and existing ReadPacket calls will first check whether there is data available in the `stale` variable before they error out
- The `close` function call in `Async` connections was modified to set a final write deadline for its final writer flush
- Refactored the `handlePacket` functions for both servers and clients to be clearer and avoid allocations

Fixes #70

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] Bug fix (non-breaking change which fixes an issue) [title: 'fix:']

## Testing

Please make sure that existing test cases pass (with `go test ./... -race` and `go test -bench=. ./... -race`),
and if required please add new test cases and list them below:

- [x] TestAsyncReadAvailableClose
- [x] TestServerStaleClose
- [x] TestClientStaleClose

## Benchmarking

Frisbee tries to adhere to strict performance requirements, so please make sure to run `go test -bench=. ./...` and paste the results below:

### Benchmarking Results:

```shell
goos: darwin
goarch: arm64
pkg: github.com/loopholelabs/frisbee
BenchmarkAsyncThroughputPipe/32_Bytes-10                  104292             11535 ns/op         277.41 MB/s         450 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/512_Bytes-10                  67843             17717 ns/op        2889.94 MB/s         450 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/1024_Bytes-10                 56389             21190 ns/op        4832.48 MB/s         450 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/2048_Bytes-10                 40431             29713 ns/op        6892.62 MB/s         451 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/4096_Bytes-10                 24122             49577 ns/op        8261.95 MB/s         463 B/op          8 allocs/op
BenchmarkAsyncThroughputNetwork/32_Bytes-10                46525             26475 ns/op         120.87 MB/s         257 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/512_Bytes-10               36973             32222 ns/op        1588.99 MB/s         257 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/1024_Bytes-10              31856             37784 ns/op        2710.17 MB/s         257 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/2048_Bytes-10              24055             49616 ns/op        4127.67 MB/s         259 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/4096_Bytes-10              16674             72020 ns/op        5687.32 MB/s         257 B/op          4 allocs/op
BenchmarkThroughputClient/test-10                             80          15630455 ns/op        2146.70 MB/s        4146 B/op          6 allocs/op
BenchmarkThroughputResponseClient/test-10                     74          16244046 ns/op        2065.61 MB/s        4523 B/op          2 allocs/op
BenchmarkThroughputServer/test-10                            114          10267932 ns/op        3267.84 MB/s        3976 B/op          1 allocs/op
BenchmarkThroughputResponseServer/test-10                    121           9903261 ns/op        3388.17 MB/s        2381 B/op          3 allocs/op
BenchmarkSyncThroughputPipe/32_Bytes-10                     7434            145954 ns/op          21.92 MB/s        1858 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/512_Bytes-10                    7282            145738 ns/op         351.32 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/1024_Bytes-10                   8126            146635 ns/op         698.33 MB/s        1860 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/2048_Bytes-10                   7977            147397 ns/op        1389.45 MB/s        1859 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/4096_Bytes-10                   7984            150511 ns/op        2721.40 MB/s        1865 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/32_Bytes-10                  3249            327235 ns/op           9.78 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/512_Bytes-10                 3075            344782 ns/op         148.50 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/1024_Bytes-10                2922            345925 ns/op         296.02 MB/s        1862 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/2048_Bytes-10                3210            351161 ns/op         583.21 MB/s        1862 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/4096_Bytes-10                3226            355124 ns/op        1153.40 MB/s        1868 B/op        204 allocs/op
BenchmarkAsyncThroughputLarge/1MB-10                         156           8039303 ns/op        13043.12 MB/s      86786 B/op          4 allocs/op
BenchmarkAsyncThroughputLarge/2MB-10                          61          16844812 ns/op        12449.84 MB/s     358628 B/op          5 allocs/op
BenchmarkAsyncThroughputLarge/4MB-10                          24          55381358 ns/op        7573.49 MB/s     1673928 B/op          8 allocs/op
BenchmarkAsyncThroughputLarge/8MB-10                           8         126047797 ns/op        6655.10 MB/s     5922318 B/op         13 allocs/op
BenchmarkAsyncThroughputLarge/16MB-10                          4         262948708 ns/op        6380.41 MB/s    19663306 B/op         20 allocs/op
BenchmarkSyncThroughputLarge/1MB-10                           80          14436041 ns/op        7263.60 MB/s     2819653 B/op        221 allocs/op
BenchmarkSyncThroughputLarge/2MB-10                           40          29143953 ns/op        7195.84 MB/s     1061062 B/op        207 allocs/op
BenchmarkSyncThroughputLarge/4MB-10                           21          57441837 ns/op        7301.83 MB/s    20106985 B/op        240 allocs/op
BenchmarkSyncThroughputLarge/8MB-10                            9         125012273 ns/op        6710.23 MB/s    46340782 B/op        249 allocs/op
BenchmarkSyncThroughputLarge/16MB-10                           4         263560260 ns/op        6365.61 MB/s    102638996 B/op       249 allocs/op
BenchmarkTCPThroughput/32_Bytes-10                         19956             60020 ns/op          53.32 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/512_Bytes-10                        12622             95641 ns/op         535.34 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/1024_Bytes-10                        8493            140516 ns/op         728.74 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/2048_Bytes-10                        5278            239875 ns/op         853.78 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/4096_Bytes-10                        2762            444297 ns/op         921.91 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/1MB-10                                 85          14096236 ns/op        7438.69 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/2MB-10                                 40          28997252 ns/op        7232.24 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/4MB-10                                 19          59525778 ns/op        7046.20 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/8MB-10                                  9         123547968 ns/op        6789.76 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/16MB-10                                 4         255130854 ns/op        6575.93 MB/s         304 B/op          4 allocs/op
PASS
ok      github.com/loopholelabs/frisbee 77.998s
PASS
ok      github.com/loopholelabs/frisbee/internal/queue  0.161s
```

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `trunk check` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
