### PR TITLE
Feat: Decoder not Dependant on packet.packet

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,4 @@ jobs:
           key: trunk-${{ runner.os }}
 
       - name: Trunk Check
-        uses: trunk-io/trunk-action@v0.4.0-beta
+        uses: trunk-io/trunk-action@v1.0.0

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 cli:
-  version: 0.8.1-beta
+  version: 0.10.0-beta
 lint:
   enabled:
     - gitleaks@7.6.1

--- a/pkg/packet/decoder.go
+++ b/pkg/packet/decoder.go
@@ -23,35 +23,31 @@ import (
 var decoderPool sync.Pool
 
 type Decoder struct {
-	p *Packet
 	b []byte
 }
 
-func GetDecoder(p *Packet) (d *Decoder) {
+func GetDecoder(b []byte) (d *Decoder) {
 	v := decoderPool.Get()
 	if v == nil {
 		d = &Decoder{
-			p: p,
-			b: p.Content.B,
+			b: b,
 		}
 	} else {
 		d = v.(*Decoder)
-		d.p = p
-		d.b = p.Content.B
+		d.b = b
 	}
 	return
 }
 
-func Return(d *Decoder) {
+func ReturnDecoder(d *Decoder) {
 	if d != nil {
-		d.p = nil
 		d.b = nil
 		decoderPool.Put(d)
 	}
 }
 
 func (d *Decoder) Return() {
-	Return(d)
+	ReturnDecoder(d)
 }
 
 func (d *Decoder) Nil() (value bool) {

--- a/pkg/packet/decoder_test.go
+++ b/pkg/packet/decoder_test.go
@@ -28,7 +28,7 @@ func TestDecoderNil(t *testing.T) {
 	p := Get()
 	Encoder(p).Nil()
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	value := d.Nil()
 	assert.True(t, value)
 
@@ -40,7 +40,7 @@ func TestDecoderNil(t *testing.T) {
 	p.Content.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Nil()
-		d = GetDecoder(p)
+		d = GetDecoder(p.Content.B)
 		value = d.Nil()
 		d.Return()
 		p.Content.Reset()
@@ -64,7 +64,7 @@ func TestDecoderMap(t *testing.T) {
 		e.String(k).Uint32(v)
 	}
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	size, err := d.Map(StringKind, Uint32Kind)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(len(m)), size)
@@ -93,7 +93,7 @@ func TestDecoderMap(t *testing.T) {
 		for k, v = range m {
 			e.String(k).Uint32(v)
 		}
-		d = GetDecoder(p)
+		d = GetDecoder(p.Content.B)
 		size, err = d.Map(StringKind, Uint32Kind)
 		for i := uint32(0); i < size; i++ {
 			_, _ = d.String()
@@ -118,7 +118,7 @@ func TestDecoderSlice(t *testing.T) {
 		e.String(v)
 	}
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	size, err := d.Slice(StringKind)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(len(m)), size)
@@ -143,7 +143,7 @@ func TestDecoderSlice(t *testing.T) {
 		for _, v := range m {
 			e.String(v)
 		}
-		d = GetDecoder(p)
+		d = GetDecoder(p.Content.B)
 		size, err = d.Slice(StringKind)
 		for i := uint32(0); i < size; i++ {
 			_, _ = d.String()
@@ -164,7 +164,7 @@ func TestDecoderBytes(t *testing.T) {
 
 	Encoder(p).Bytes(v)
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	value, err := d.Bytes(nil)
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -177,7 +177,7 @@ func TestDecoderBytes(t *testing.T) {
 	p.Content.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Bytes(v)
-		d = GetDecoder(p)
+		d = GetDecoder(p.Content.B)
 		value, err = d.Bytes(value)
 		d.Return()
 		p.Content.Reset()
@@ -195,7 +195,7 @@ func TestDecoderString(t *testing.T) {
 
 	Encoder(p).String(v)
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	value, err := d.String()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -208,7 +208,7 @@ func TestDecoderString(t *testing.T) {
 	p.Content.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).String(v)
-		d = GetDecoder(p)
+		d = GetDecoder(p.Content.B)
 		value, err = d.String()
 		d.Return()
 		p.Content.Reset()
@@ -226,7 +226,7 @@ func TestDecoderError(t *testing.T) {
 
 	Encoder(p).Error(v)
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	value, err := d.Error()
 	assert.NoError(t, err)
 	assert.ErrorIs(t, value, v)
@@ -239,7 +239,7 @@ func TestDecoderError(t *testing.T) {
 	p.Content.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Error(v)
-		d = GetDecoder(p)
+		d = GetDecoder(p.Content.B)
 		value, err = d.Error()
 		d.Return()
 		p.Content.Reset()
@@ -255,7 +255,7 @@ func TestDecoderBool(t *testing.T) {
 	p := Get()
 	Encoder(p).Bool(true)
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	value, err := d.Bool()
 	assert.NoError(t, err)
 	assert.True(t, value)
@@ -268,7 +268,7 @@ func TestDecoderBool(t *testing.T) {
 	p.Content.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Bool(true)
-		d = GetDecoder(p)
+		d = GetDecoder(p.Content.B)
 		value, err = d.Bool()
 		d.Return()
 		p.Content.Reset()
@@ -286,7 +286,7 @@ func TestDecoderUint8(t *testing.T) {
 
 	Encoder(p).Uint8(v)
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	value, err := d.Uint8()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -299,7 +299,7 @@ func TestDecoderUint8(t *testing.T) {
 	p.Content.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Uint8(v)
-		d = GetDecoder(p)
+		d = GetDecoder(p.Content.B)
 		value, err = d.Uint8()
 		d.Return()
 		p.Content.Reset()
@@ -317,7 +317,7 @@ func TestDecoderUint16(t *testing.T) {
 
 	Encoder(p).Uint16(v)
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	value, err := d.Uint16()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -330,7 +330,7 @@ func TestDecoderUint16(t *testing.T) {
 	p.Content.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Uint16(v)
-		d = GetDecoder(p)
+		d = GetDecoder(p.Content.B)
 		value, err = d.Uint16()
 		d.Return()
 		p.Content.Reset()
@@ -348,7 +348,7 @@ func TestDecoderUint32(t *testing.T) {
 
 	Encoder(p).Uint32(v)
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	value, err := d.Uint32()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -361,7 +361,7 @@ func TestDecoderUint32(t *testing.T) {
 	p.Content.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Uint32(v)
-		d = GetDecoder(p)
+		d = GetDecoder(p.Content.B)
 		value, err = d.Uint32()
 		d.Return()
 		p.Content.Reset()
@@ -379,7 +379,7 @@ func TestDecoderUint64(t *testing.T) {
 
 	Encoder(p).Uint64(v)
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	value, err := d.Uint64()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -392,7 +392,7 @@ func TestDecoderUint64(t *testing.T) {
 	p.Content.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Uint64(v)
-		d = GetDecoder(p)
+		d = GetDecoder(p.Content.B)
 		value, err = d.Uint64()
 		d.Return()
 		p.Content.Reset()
@@ -410,7 +410,7 @@ func TestDecoderInt32(t *testing.T) {
 
 	Encoder(p).Int32(v)
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	value, err := d.Int32()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -423,7 +423,7 @@ func TestDecoderInt32(t *testing.T) {
 	p.Content.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Int32(v)
-		d = GetDecoder(p)
+		d = GetDecoder(p.Content.B)
 		value, err = d.Int32()
 		d.Return()
 		p.Content.Reset()
@@ -441,7 +441,7 @@ func TestDecoderInt64(t *testing.T) {
 
 	Encoder(p).Int64(v)
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	value, err := d.Int64()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -454,7 +454,7 @@ func TestDecoderInt64(t *testing.T) {
 	p.Content.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Int64(v)
-		d = GetDecoder(p)
+		d = GetDecoder(p.Content.B)
 		value, err = d.Int64()
 		d.Return()
 		p.Content.Reset()
@@ -472,7 +472,7 @@ func TestDecoderFloat32(t *testing.T) {
 
 	Encoder(p).Float32(v)
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	value, err := d.Float32()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -485,7 +485,7 @@ func TestDecoderFloat32(t *testing.T) {
 	p.Content.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Float32(v)
-		d = GetDecoder(p)
+		d = GetDecoder(p.Content.B)
 		value, err = d.Float32()
 		d.Return()
 		p.Content.Reset()
@@ -503,7 +503,7 @@ func TestDecoderFloat64(t *testing.T) {
 
 	Encoder(p).Float64(v)
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	value, err := d.Float64()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -516,7 +516,7 @@ func TestDecoderFloat64(t *testing.T) {
 	p.Content.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Float64(v)
-		d = GetDecoder(p)
+		d = GetDecoder(p.Content.B)
 		value, err = d.Float64()
 		d.Return()
 		p.Content.Reset()

--- a/pkg/packet/packet_test.go
+++ b/pkg/packet/packet_test.go
@@ -302,7 +302,7 @@ func TestCompleteChain(t *testing.T) {
 	val := new(testStruct)
 	var err error
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 
 	val.err, err = d.Error()
 	assert.NoError(t, err)
@@ -391,7 +391,7 @@ func TestCompleteChain(t *testing.T) {
 	p.Content.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Error(test.err).String(test.test).Bytes(test.b).Uint8(test.num1).Uint16(test.num2).Uint32(test.num3).Uint64(test.num4).Bool(test.truth).Nil()
-		d = GetDecoder(p)
+		d = GetDecoder(p.Content.B)
 		val.err, err = d.Error()
 		val.test, err = d.String()
 		val.b, err = d.Bytes(val.b)
@@ -413,7 +413,7 @@ func TestNilSlice(t *testing.T) {
 	p := Get()
 	Encoder(p).Slice(uint32(len(s)), StringKind)
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	j, err := d.Slice(StringKind)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(len(s)), j)
@@ -431,7 +431,7 @@ func TestError(t *testing.T) {
 	p := Get()
 	Encoder(p).Error(v)
 
-	d := GetDecoder(p)
+	d := GetDecoder(p.Content.B)
 	_, err := d.String()
 	assert.ErrorIs(t, err, InvalidString)
 

--- a/protoc-gen-frisbee/templates/decode.templ
+++ b/protoc-gen-frisbee/templates/decode.templ
@@ -3,7 +3,7 @@ func (x *{{ CamelCase .FullName }}) Decode (p *packet.Packet) error {
     if x == nil {
         return NilDecode
     }
-    d := packet.GetDecoder(p)
+    d := packet.GetDecoder(p.Content.B)
     return x.decode(d)
 }
 {{end}}


### PR DESCRIPTION
## Description

This PR changes the `pkg/packet` package and removes the decoder's dependency on the `packet.Packet` structure. Instead it's now possible to pass in a byte slice directly into the decoder. It also updates the RPC template for creating decoders for structs to use the new decoder API. 

This change also updates the trunk linter to v0.10.0-beta. 

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).
- [x] New feature (non-breaking change which adds functionality) [title: 'feat:']
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

All test cases in `decoder_test.go` have been updated

## Benchmarking

Frisbee tries to adhere to strict performance requirements, so please make sure to run `go test -bench=. ./...` and paste the results below:

### Benchmarking Results:

```shell
goos: darwin
goarch: arm64
pkg: github.com/loopholelabs/frisbee
BenchmarkAsyncThroughputPipe/32_Bytes-10           98272             10464 ns/op         305.82 MB/s         460 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/512_Bytes-10          93852             12986 ns/op        3942.65 MB/s         454 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/1024_Bytes-10         59259             20013 ns/op        5116.79 MB/s         469 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/2048_Bytes-10         44276             27122 ns/op        7551.08 MB/s         477 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/4096_Bytes-10         26535             45042 ns/op        9093.70 MB/s         537 B/op          9 allocs/op
BenchmarkAsyncThroughputNetwork/32_Bytes-10        55257             21207 ns/op         150.89 MB/s         260 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/512_Bytes-10       44468             27458 ns/op        1864.66 MB/s         260 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/1024_Bytes-10      34792             34782 ns/op        2944.05 MB/s         261 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/2048_Bytes-10      26581             45112 ns/op        4539.79 MB/s         263 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/4096_Bytes-10      18492             65417 ns/op        6261.34 MB/s         266 B/op          4 allocs/op
BenchmarkThroughputClient/test-10                    100          10737638 ns/op        3124.89 MB/s       15338 B/op         40 allocs/op
BenchmarkThroughputResponseClient/test-10            100          10735209 ns/op        3125.60 MB/s       12654 B/op         45 allocs/op
BenchmarkThroughputServer/test-10                    100          10912764 ns/op        3074.74 MB/s       13078 B/op         55 allocs/op
BenchmarkThroughputResponseServer/test-10            100          10667353 ns/op        3145.48 MB/s        8437 B/op         15 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/1_Pair,_32_Bytes-10                56064             21535 ns/op         148.59 MB/s         303 B/op          4 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/2_Pair,_32_Bytes-10                46946             25554 ns/op         125.22 MB/s         627 B/op          8 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/5_Pair,_32_Bytes-10                36470             35478 ns/op          90.20 MB/s        1636 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/10_Pair,_32_Bytes-10               16044             69805 ns/op          45.84 MB/s        4113 B/op         40 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/Half_CPU_Pair,_32_Bytes-10         34454             40510 ns/op          78.99 MB/s        1657 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/CPU_Pair,_32_Bytes-10              17062             69545 ns/op          46.01 MB/s        4028 B/op         40 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/1_Pair,_512_Bytes-10               42282             28331 ns/op        1807.23 MB/s         316 B/op          4 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/2_Pair,_512_Bytes-10               39254             30976 ns/op        1652.89 MB/s         647 B/op          8 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/5_Pair,_512_Bytes-10               31563             37929 ns/op        1349.90 MB/s        1685 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/10_Pair,_512_Bytes-10              11474            109236 ns/op         468.71 MB/s        4709 B/op         40 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/Half_CPU_Pair,_512_Bytes-10        31705             40370 ns/op        1268.28 MB/s        1689 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/CPU_Pair,_512_Bytes-10             11390            120848 ns/op         423.67 MB/s        4731 B/op         40 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/1_Pair,_4096_Bytes-10              18042             68314 ns/op        5995.84 MB/s         402 B/op          4 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/2_Pair,_4096_Bytes-10              17140             70649 ns/op        5797.66 MB/s         860 B/op          8 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/5_Pair,_4096_Bytes-10               3769            270784 ns/op        1512.64 MB/s        5058 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/10_Pair,_4096_Bytes-10              1966            570838 ns/op         717.54 MB/s       16633 B/op         42 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/Half_CPU_Pair,_4096_Bytes-10                5433            264960 ns/op        1545.90 MB/s        3893 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/CPU_Pair,_4096_Bytes-10                     1990            574069 ns/op         713.50 MB/s       16496 B/op         42 allocs/op
BenchmarkSyncThroughputPipe/32_Bytes-10                                             9056            129619 ns/op          24.69 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/512_Bytes-10                                            9315            130239 ns/op         393.12 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/1024_Bytes-10                                           9182            129580 ns/op         790.24 MB/s        1858 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/2048_Bytes-10                                           8972            131543 ns/op        1556.90 MB/s        1860 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/4096_Bytes-10                                           8472            139095 ns/op        2944.75 MB/s        1862 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/32_Bytes-10                                          3367            359091 ns/op           8.91 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/512_Bytes-10                                         2824            394177 ns/op         129.89 MB/s        1858 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/1024_Bytes-10                                        2896            402388 ns/op         254.48 MB/s        1860 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/2048_Bytes-10                                        2570            419012 ns/op         488.77 MB/s        1859 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/4096_Bytes-10                                        2667            443223 ns/op         924.14 MB/s        1866 B/op        204 allocs/op
BenchmarkAsyncThroughputLarge/1MB-10                                                 153           8490241 ns/op        12350.37 MB/s      40870 B/op          4 allocs/op
BenchmarkAsyncThroughputLarge/2MB-10                                                  69          16456510 ns/op        12743.60 MB/s     213630 B/op          5 allocs/op
BenchmarkAsyncThroughputLarge/4MB-10                                                  26          49865117 ns/op        8411.30 MB/s      328202 B/op          5 allocs/op
BenchmarkAsyncThroughputLarge/8MB-10                                                  10         111526017 ns/op        7521.66 MB/s     3422042 B/op          9 allocs/op
BenchmarkAsyncThroughputLarge/16MB-10                                                  5         212016525 ns/op        7913.16 MB/s    10815075 B/op         13 allocs/op
BenchmarkSyncThroughputLarge/1MB-10                                                  105          10802363 ns/op        9706.91 MB/s     4046023 B/op        228 allocs/op
BenchmarkSyncThroughputLarge/2MB-10                                                   58          22884392 ns/op        9164.11 MB/s     6393482 B/op        225 allocs/op
BenchmarkSyncThroughputLarge/4MB-10                                                   25          53179165 ns/op        7887.12 MB/s     5068404 B/op        213 allocs/op
BenchmarkSyncThroughputLarge/8MB-10                                                    9         111507676 ns/op        7522.90 MB/s    50974677 B/op        254 allocs/op
BenchmarkSyncThroughputLarge/16MB-10                                                   5         244105750 ns/op        6872.93 MB/s    102638995 B/op       249 allocs/op
BenchmarkTCPThroughput/32_Bytes-10                                                 22972             52469 ns/op          60.99 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/512_Bytes-10                                                13771             87298 ns/op         586.50 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/1024_Bytes-10                                               10000            131682 ns/op         777.63 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/2048_Bytes-10                                                5676            223211 ns/op         917.52 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/4096_Bytes-10                                                2936            420668 ns/op         973.69 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/1MB-10                                                         98          13266514 ns/op        7903.93 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/2MB-10                                                         42          26370429 ns/op        7952.67 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/4MB-10                                                         21          54311603 ns/op        7722.67 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/8MB-10                                                         10         115272821 ns/op        7277.18 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/16MB-10                                                         5         243053242 ns/op        6902.69 MB/s         304 B/op          4 allocs/op
PASS
ok      github.com/loopholelabs/frisbee 105.804s
?       github.com/loopholelabs/frisbee/dist/simple     [no test files]
?       github.com/loopholelabs/frisbee/internal/dialer [no test files]
PASS
ok      github.com/loopholelabs/frisbee/internal/queue  0.168s
?       github.com/loopholelabs/frisbee/pkg/content     [no test files]
goos: darwin
goarch: arm64
pkg: github.com/loopholelabs/frisbee/pkg/metadata
BenchmarkEncodeHandler-10               200226435                5.948 ns/op
BenchmarkDecodeHandler-10               252098125                4.760 ns/op
BenchmarkEncodeDecodeHandler-10         85965020                14.09 ns/op
BenchmarkEncode-10                      223147456                5.375 ns/op
BenchmarkDecode-10                      310581544                3.858 ns/op
BenchmarkEncodeDecode-10                100000000               11.29 ns/op
PASS
ok      github.com/loopholelabs/frisbee/pkg/metadata    9.268s
PASS
ok      github.com/loopholelabs/frisbee/pkg/packet      0.101s
?       github.com/loopholelabs/frisbee/protoc-gen-frisbee      [no test files]
?       github.com/loopholelabs/frisbee/protoc-gen-frisbee/internal/utils       [no test files]
?       github.com/loopholelabs/frisbee/protoc-gen-frisbee/internal/version     [no test files]
?       github.com/loopholelabs/frisbee/protoc-gen-frisbee/pkg/generator        [no test files]

```

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `trunk check` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
