### PR TITLE
Fix(#94) - Fixing Missing Templates 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## Fixes
+
+- Version [v0.4.2][v0.4.2] did not embed the templates for RPC generation into frisbee, leading to runtime panics when
+  generating RPC frameworks from outside the frisbee repository directory. This has now been fixed by embedding the
+  templates into the compiled plugin binary file.
+
 ## [v0.4.2] - 2022-04-20 (Beta)
 
 ## Changes
@@ -219,16 +225,28 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Initial Release of Frisbee
 
-[unreleased]: https://github.com/loopholelabs/frisbee/compare/v0.4.2...HEAD
+[unreleased]: https://github.com/loopholelabs/frisbee/compare/v0.4.3...HEAD
+
+[v0.4.3]: https://github.com/loopholelabs/frisbee/compare/v0.4.2...v0.4.3
+
 [v0.4.2]: https://github.com/loopholelabs/frisbee/compare/v0.4.1...v0.4.2
+
 [v0.4.1]: https://github.com/loopholelabs/frisbee/compare/v0.4.0...v0.4.1
+
 [v0.4.0]: https://github.com/loopholelabs/frisbee/compare/v0.3.2...v0.4.0
+
 [v0.3.2]: https://github.com/loopholelabs/frisbee/compare/v0.3.1...v0.3.2
+
 [v0.3.1]: https://github.com/loopholelabs/frisbee/compare/v0.3.0...v0.3.1
+
 [v0.3.0]: https://github.com/loopholelabs/frisbee/compare/v0.2.4...v0.3.0
+
 [v0.2.4]: https://github.com/loopholelabs/frisbee/compare/v0.2.3...v0.2.4
+
 [v0.2.3]: https://github.com/loopholelabs/frisbee/compare/v0.2.2...v0.2.3
+
 [v0.2.2]: https://github.com/loopholelabs/frisbee/compare/v0.2.1...v0.2.2
+
 [v0.2.1]: https://github.com/loopholelabs/frisbee/compare/v0.2.0...v0.2.1
 [v0.2.0]: https://github.com/loopholelabs/frisbee/compare/v0.1.6...v0.2.0
 [v0.1.6]: https://github.com/loopholelabs/frisbee/compare/v0.1.5...v0.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,27 +226,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Initial Release of Frisbee
 
 [unreleased]: https://github.com/loopholelabs/frisbee/compare/v0.4.3...HEAD
-
 [v0.4.3]: https://github.com/loopholelabs/frisbee/compare/v0.4.2...v0.4.3
-
 [v0.4.2]: https://github.com/loopholelabs/frisbee/compare/v0.4.1...v0.4.2
-
 [v0.4.1]: https://github.com/loopholelabs/frisbee/compare/v0.4.0...v0.4.1
-
 [v0.4.0]: https://github.com/loopholelabs/frisbee/compare/v0.3.2...v0.4.0
-
 [v0.3.2]: https://github.com/loopholelabs/frisbee/compare/v0.3.1...v0.3.2
-
 [v0.3.1]: https://github.com/loopholelabs/frisbee/compare/v0.3.0...v0.3.1
-
 [v0.3.0]: https://github.com/loopholelabs/frisbee/compare/v0.2.4...v0.3.0
-
 [v0.2.4]: https://github.com/loopholelabs/frisbee/compare/v0.2.3...v0.2.4
-
 [v0.2.3]: https://github.com/loopholelabs/frisbee/compare/v0.2.2...v0.2.3
-
 [v0.2.2]: https://github.com/loopholelabs/frisbee/compare/v0.2.1...v0.2.2
-
 [v0.2.1]: https://github.com/loopholelabs/frisbee/compare/v0.2.0...v0.2.1
 [v0.2.0]: https://github.com/loopholelabs/frisbee/compare/v0.1.6...v0.2.0
 [v0.1.6]: https://github.com/loopholelabs/frisbee/compare/v0.1.5...v0.1.6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/loopholelabs/frisbee
 
-go 1.15
+go 1.16
 
 require (
 	github.com/loopholelabs/testing v0.2.3

--- a/protoc-gen-frisbee/pkg/generator/generator.go
+++ b/protoc-gen-frisbee/pkg/generator/generator.go
@@ -19,6 +19,7 @@ package generator
 import (
 	"github.com/loopholelabs/frisbee/protoc-gen-frisbee/internal/utils"
 	"github.com/loopholelabs/frisbee/protoc-gen-frisbee/internal/version"
+	"github.com/loopholelabs/frisbee/protoc-gen-frisbee/templates"
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/pluginpb"
@@ -27,6 +28,27 @@ import (
 
 type Generator struct {
 	options *protogen.Options
+}
+
+var templ *template.Template
+
+func init() {
+	templ = template.Must(template.New("main").Funcs(template.FuncMap{
+		"CamelCase":          utils.CamelCaseFullName,
+		"CamelCaseName":      utils.CamelCaseName,
+		"MakeIterable":       utils.MakeIterable,
+		"Counter":            utils.Counter,
+		"FirstLowerCase":     utils.FirstLowerCase,
+		"FirstLowerCaseName": utils.FirstLowerCaseName,
+		"FindValue":          findValue,
+		"GetKind":            getKind,
+		"GetLUTEncoder":      getLUTEncoder,
+		"GetLUTDecoder":      getLUTDecoder,
+		"GetEncodingFields":  getEncodingFields,
+		"GetDecodingFields":  getDecodingFields,
+		"GetKindLUT":         getKindLUT,
+		"GetServerFields":    getServerFields,
+	}).ParseFS(templates.FS, "*"))
 }
 
 func New() *Generator {
@@ -52,23 +74,6 @@ func (g *Generator) Generate(req *pluginpb.CodeGeneratorRequest) (res *pluginpb.
 	if err != nil {
 		return nil, err
 	}
-
-	templ := template.Must(template.New("main").Funcs(template.FuncMap{
-		"CamelCase":          utils.CamelCaseFullName,
-		"CamelCaseName":      utils.CamelCaseName,
-		"MakeIterable":       utils.MakeIterable,
-		"Counter":            utils.Counter,
-		"FirstLowerCase":     utils.FirstLowerCase,
-		"FirstLowerCaseName": utils.FirstLowerCaseName,
-		"FindValue":          findValue,
-		"GetKind":            getKind,
-		"GetLUTEncoder":      getLUTEncoder,
-		"GetLUTDecoder":      getLUTDecoder,
-		"GetEncodingFields":  getEncodingFields,
-		"GetDecodingFields":  getDecodingFields,
-		"GetKindLUT":         getKindLUT,
-		"GetServerFields":    getServerFields,
-	}).ParseGlob("protoc-gen-frisbee/templates/*"))
 
 	for _, f := range plugin.Files {
 		if !f.Generate {

--- a/protoc-gen-frisbee/templates/templates.go
+++ b/protoc-gen-frisbee/templates/templates.go
@@ -1,0 +1,22 @@
+/*
+	Copyright 2022 Loophole Labs
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		   http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package templates
+
+import "embed"
+
+//go:embed *
+var FS embed.FS


### PR DESCRIPTION
## Description

This PR changes the RPC generator to embed the template files into the protoc plugin binary and then generate templates using that embedded template filesystem instead of the OS filesystem. 

Fixes #94 

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] Bug fix (non-breaking change which fixes an issue) [title: 'fix:']

## Testing

N/A

## Benchmarking

N/A

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `trunk check` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
