### PR TITLE
Feat: Generated RPC Code does not rely on *packet.Packet for decoding

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -6,7 +6,7 @@ on:
       - "*"
 
 jobs:
-  tests:
+  benchmark:
     runs-on: ubuntu-latest
     steps:
       - id: go-cache-paths
@@ -35,8 +35,35 @@ jobs:
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
       - name: Benchmark
-        run: go test -bench=. -v ./...
+        run: go test -run=^$ -bench=. -v ./...
+  benchmark-race:
+    runs-on: ubuntu-latest
+    steps:
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
       - name: Benchmark with Race Conditions
-        run: go test -bench=. -race -timeout 30m -v ./...
+        run: go test -run=^$ -bench=. -race -timeout 30m -v ./...
         timeout-minutes: 30

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,33 @@ jobs:
 
       - name: Test
         run: go test -v ./...
+  tests-race:
+    runs-on: ubuntu-latest
+    steps:
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
       - name: Test with Race Conditions
         run: go test -race -v ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## Changes
+
+- Generated RPC Code for decoding objects no longer relies on the `*packet.Packet` structure, and instead works with `[]byte` slices directly
+
 ## [v0.4.3] - 2022-04-20 (Beta)
 
 ## Fixes

--- a/protoc-gen-frisbee/templates/client.templ
+++ b/protoc-gen-frisbee/templates/client.templ
@@ -56,7 +56,7 @@ func NewClient (tlsConfig *tls.Config, logger *zerolog.Logger) (*Client, error) 
             if ch, ok := c.inflight{{ CamelCaseName $method.Name }}[incoming.Metadata.Id]; ok {
                 c.inflight{{ CamelCaseName $method.Name }}Mu.RUnlock()
                 res := New{{ CamelCase $method.Output.FullName }}()
-                res.Decode(incoming)
+                res.Decode(incoming.Content.B)
                 ch <- res
             } else {
                 c.inflight{{ CamelCaseName $method.Name }}Mu.RUnlock()

--- a/protoc-gen-frisbee/templates/decode.templ
+++ b/protoc-gen-frisbee/templates/decode.templ
@@ -1,9 +1,9 @@
 {{define "decode"}}
-func (x *{{ CamelCase .FullName }}) Decode (p *packet.Packet) error {
+func (x *{{ CamelCase .FullName }}) Decode (b []byte) error {
     if x == nil {
         return NilDecode
     }
-    d := packet.GetDecoder(p.Content.B)
+    d := packet.GetDecoder(b)
     return x.decode(d)
 }
 {{end}}

--- a/protoc-gen-frisbee/templates/server.templ
+++ b/protoc-gen-frisbee/templates/server.templ
@@ -33,7 +33,7 @@ type Server struct {
             {{ $count := call $counter -}}
             table[{{ $count }}] = func(ctx context.Context, incoming *packet.Packet) (outgoing *packet.Packet, action frisbee.Action) {
                 req := New{{ CamelCase $method.Input.FullName  }}()
-                err := req.Decode(incoming)
+                err := req.Decode(incoming.Content.B)
                 if err == nil {
                     if req.ignore {
                         {{ FirstLowerCaseName $service.Name }}.{{ CamelCaseName $method.Name }}(ctx, req)


### PR DESCRIPTION
## Description

As part of Lynk we want the ability to encode and decode arbitrary structs to byte slices and vice-versa. By removing the dependency on `*packet.Packet` from all the generated decode logic, we are able to achieve this automatically using the RPC framework. 

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] New feature (non-breaking change which adds functionality) [title: 'feat:']

## Testing

N/A

## Benchmarking

N/A

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `trunk check` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
