### PR TITLE
Fix: #102 - Fixing the packet decoder 

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 cli:
-  version: 0.10.0-beta
+  version: 0.10.1-beta
 lint:
   enabled:
     - gitleaks@8.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## Fixes
+
+- Fixing issue where packet.Decoder would return the decoder back to the pool before decoding was complete (Issue #102)
+
+## Changes
+
+- Updating Trunk Linter to `v0.10.1-beta`
+
 ## [v0.4.4] - 2022-04-21 (Beta)
 
 ## Changes

--- a/protoc-gen-frisbee/templates/decode.templ
+++ b/protoc-gen-frisbee/templates/decode.templ
@@ -4,6 +4,7 @@ func (x *{{ CamelCase .FullName }}) Decode (b []byte) error {
         return NilDecode
     }
     d := packet.GetDecoder(b)
+    defer d.Return()
     return x.decode(d)
 }
 {{end}}
@@ -88,7 +89,6 @@ func (x *{{CamelCase .FullName}}) decode(d *packet.Decoder) error {
             {{end -}}
         {{end -}}
     }
-    d.Return()
     return nil
 }
 {{end}}


### PR DESCRIPTION
## Description

This PR is 2 LOC but it moves the returning of the `packet.Decoder` from inside the `decode` function (the internal decoder) to the external decode function (`Decode`). This allows us to guarantee that the decoder will not be returned to the pool until after it is finished being used. 

Fixes #102 

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] Bug fix (non-breaking change which fixes an issue) [title: 'fix:']

## Testing

This bug will be addressed as part of #91 

## Benchmarking

N/A

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `trunk check` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
