### PR TITLE
Release v0.4.5

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 cli:
-  version: 0.10.0-beta
+  version: 0.10.1-beta
 lint:
   enabled:
     - gitleaks@8.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## Fixes
+
+- Fixing issue where packet.Decoder would return the decoder back to the pool before decoding was complete (Issue #102)
+
+## Changes
+
+- Updating Trunk Linter to `v0.10.1-beta`
+
 ## [v0.4.4] - 2022-04-21 (Beta)
 
 ## Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [v0.4.5] - 2022-04-22 (Beta)
+
 ## Fixes
 
 - Fixing issue where packet.Decoder would return the decoder back to the pool before decoding was complete (Issue #102)
@@ -245,7 +247,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Initial Release of Frisbee
 
-[unreleased]: https://github.com/loopholelabs/frisbee/compare/v0.4.4...HEAD
+[unreleased]: https://github.com/loopholelabs/frisbee/compare/v0.4.5...HEAD
+[v0.4.5]: https://github.com/loopholelabs/frisbee/compare/v0.4.4...v0.4.5
 [v0.4.4]: https://github.com/loopholelabs/frisbee/compare/v0.4.3...v0.4.4
 [v0.4.3]: https://github.com/loopholelabs/frisbee/compare/v0.4.2...v0.4.3
 [v0.4.2]: https://github.com/loopholelabs/frisbee/compare/v0.4.1...v0.4.2

--- a/protoc-gen-frisbee/dockerfile
+++ b/protoc-gen-frisbee/dockerfile
@@ -2,7 +2,7 @@ FROM golang as builder
 
 ENV GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 
-RUN go install github.com/loopholelabs/frisbee/protoc-gen-frisbee@v0.4.4
+RUN go install github.com/loopholelabs/frisbee/protoc-gen-frisbee@v0.4.5
 
 # Note, the Docker images must be built for amd64. If the host machine architecture is not amd64
 # you need to cross-compile the binary and move it into /go/bin.
@@ -12,7 +12,7 @@ FROM scratch
 
 # Runtime dependencies
 LABEL "build.buf.plugins.runtime_library_versions.0.name"="github.com/loopholelabs/frisbee"
-LABEL "build.buf.plugins.runtime_library_versions.0.version"="v0.4.4"
+LABEL "build.buf.plugins.runtime_library_versions.0.version"="v0.4.5"
 
 COPY --from=builder /go/bin /
 

--- a/protoc-gen-frisbee/templates/decode.templ
+++ b/protoc-gen-frisbee/templates/decode.templ
@@ -4,6 +4,7 @@ func (x *{{ CamelCase .FullName }}) Decode (b []byte) error {
         return NilDecode
     }
     d := packet.GetDecoder(b)
+    defer d.Return()
     return x.decode(d)
 }
 {{end}}
@@ -88,7 +89,6 @@ func (x *{{CamelCase .FullName}}) decode(d *packet.Decoder) error {
             {{end -}}
         {{end -}}
     }
-    d.Return()
     return nil
 }
 {{end}}


### PR DESCRIPTION
## Fixes

- Fixing issue where packet.Decoder would return the decoder back to the pool before decoding was complete (Issue #102)

## Changes

- Updating Trunk Linter to `v0.10.1-beta`