### PR TITLE
Fix: #101 - RPC generation when the number of services is 0

### DIFF
--- a/protoc-gen-frpc/examples/norpc/norpc.proto
+++ b/protoc-gen-frpc/examples/norpc/norpc.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+option go_package = "/norpc";
+
+service NoRPC {}
+
+message Request {
+  string Message = 1;
+}
+
+message Response{
+  string Message = 1;
+}

--- a/protoc-gen-frpc/examples/noservice/noservice.proto
+++ b/protoc-gen-frpc/examples/noservice/noservice.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+option go_package = "/noservice";
+
+message Request {
+  string Message = 1;
+}
+
+message Response{
+  string Message = 1;
+}

--- a/protoc-gen-frpc/pkg/generator/generator.go
+++ b/protoc-gen-frpc/pkg/generator/generator.go
@@ -87,14 +87,25 @@ func (g *Generator) Generate(req *pluginpb.CodeGeneratorRequest) (res *pluginpb.
 			packageName = string(f.GoPackageName)
 		}
 
+		numServices := f.Desc.Services().Len()
+
+		numMethods := 0
+		for i := 0; i < numServices; i++ {
+			numMethods += f.Desc.Services().Get(i).Methods().Len()
+		}
+
 		err = templ.ExecuteTemplate(genFile, "base.templ", map[string]interface{}{
-			"pluginVersion": version.Version,
-			"sourcePath":    f.Desc.Path(),
-			"package":       packageName,
-			"imports":       requiredImports,
-			"enums":         f.Desc.Enums(),
-			"messages":      f.Desc.Messages(),
-			"services":      f.Desc.Services(),
+			"pluginVersion":   version.Version,
+			"sourcePath":      f.Desc.Path(),
+			"package":         packageName,
+			"requiredImports": requiredImports,
+			"serviceImports":  serviceImports,
+			"methodImports":   methodImports,
+			"enums":           f.Desc.Enums(),
+			"messages":        f.Desc.Messages(),
+			"services":        f.Desc.Services(),
+			"numServices":     numServices,
+			"numMethods":      numMethods,
 		})
 		if err != nil {
 			return nil, err

--- a/protoc-gen-frpc/pkg/generator/imports.go
+++ b/protoc-gen-frpc/pkg/generator/imports.go
@@ -18,12 +18,18 @@ package generator
 
 var (
 	requiredImports = []string{
-		"github.com/loopholelabs/frisbee",
 		"github.com/loopholelabs/frisbee/pkg/packet",
+		"errors",
+	}
+
+	serviceImports = []string{
+		"github.com/loopholelabs/frisbee",
 		"github.com/rs/zerolog",
 		"crypto/tls",
-		"github.com/pkg/errors",
 		"context",
+	}
+
+	methodImports = []string{
 		"sync",
 		"sync/atomic",
 	}

--- a/protoc-gen-frpc/templates/base.templ
+++ b/protoc-gen-frpc/templates/base.templ
@@ -2,9 +2,7 @@
 
 {{template "imports" .}}
 
-var (
-    NilDecode = errors.New("cannot decode into a nil root struct")
-)
+{{template "errors" .}}
 
 {{template "enums" .}}
 
@@ -12,6 +10,8 @@ var (
 
 {{template "interfaces" .}}
 
+{{ if .numServices }}
 {{template "server" .}}
 
 {{template "client" .}}
+{{ end }}

--- a/protoc-gen-frpc/templates/errors.templ
+++ b/protoc-gen-frpc/templates/errors.templ
@@ -1,0 +1,5 @@
+{{define "errors"}}
+var (
+    NilDecode = errors.New("cannot decode into a nil root struct")
+)
+{{end}}

--- a/protoc-gen-frpc/templates/imports.templ
+++ b/protoc-gen-frpc/templates/imports.templ
@@ -1,7 +1,17 @@
 {{define "imports"}}
 import (
-{{range $im := .imports -}}
+{{range $im := .requiredImports -}}
     "{{$im}}"
 {{end -}}
+{{ if .numServices }}
+{{range $im := .serviceImports -}}
+    "{{$im}}"
+{{end -}}
+{{end}}
+{{ if .numMethods }}
+{{range $im := .methodImports -}}
+    "{{$im}}"
+{{end -}}
+{{end}}
 )
 {{end}}

--- a/protoc-gen-frpc/templates/server.templ
+++ b/protoc-gen-frpc/templates/server.templ
@@ -2,7 +2,8 @@
 type Server struct {
     *frisbee.Server
 }
-    func NewServer({{ GetServerFields .services }}, tlsConfig *tls.Config, logger *zerolog.Logger) (*Server, error) {
+
+func NewServer({{ GetServerFields .services }}, tlsConfig *tls.Config, logger *zerolog.Logger) (*Server, error) {
         table := make(frisbee.HandlerTable)
         {{template "serverhandlers" .services -}}
         var s *frisbee.Server


### PR DESCRIPTION
## Description

FRPC crashes when the number of services in a proto3 file is 0, or when the total number of methods across all defined services is 0. 

Fixes #101 

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] Bug fix (non-breaking change which fixes an issue) [title: 'fix:']
## Testing

Please make sure that existing test cases pass (with `go test ./... -race` and `go test -bench=. ./... -race`),
and if required please add new test cases and list them below:

N/A

## Benchmarking

N/A

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `trunk check` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
