### PR TITLE
Fix: Multiple connections

### DIFF
--- a/async_test.go
+++ b/async_test.go
@@ -555,6 +555,7 @@ func BenchmarkAsyncThroughputNetworkMultiple(b *testing.B) {
 	b.Run("10 Pair, 32 Bytes", runner(10, 32))
 	b.Run("Half CPU Pair, 32 Bytes", runner(runtime.NumCPU()/2, 32))
 	b.Run("CPU Pair, 32 Bytes", runner(runtime.NumCPU(), 32))
+	b.Run("Double CPU Pair, 32 Bytes", runner(runtime.NumCPU()*2, 32))
 
 	b.Run("1 Pair, 512 Bytes", runner(1, 512))
 	b.Run("2 Pair, 512 Bytes", runner(2, 512))
@@ -562,6 +563,7 @@ func BenchmarkAsyncThroughputNetworkMultiple(b *testing.B) {
 	b.Run("10 Pair, 512 Bytes", runner(10, 512))
 	b.Run("Half CPU Pair, 512 Bytes", runner(runtime.NumCPU()/2, 512))
 	b.Run("CPU Pair, 512 Bytes", runner(runtime.NumCPU(), 512))
+	b.Run("Double CPU Pair, 512 Bytes", runner(runtime.NumCPU()*2, 512))
 
 	b.Run("1 Pair, 4096 Bytes", runner(1, 4096))
 	b.Run("2 Pair, 4096 Bytes", runner(2, 4096))
@@ -569,4 +571,5 @@ func BenchmarkAsyncThroughputNetworkMultiple(b *testing.B) {
 	b.Run("10 Pair, 4096 Bytes", runner(10, 4096))
 	b.Run("Half CPU Pair, 4096 Bytes", runner(runtime.NumCPU()/2, 4096))
 	b.Run("CPU Pair, 4096 Bytes", runner(runtime.NumCPU(), 4096))
+	b.Run("Double CPU Pair, 4096 Bytes", runner(runtime.NumCPU()*2, 4096))
 }

--- a/server.go
+++ b/server.go
@@ -150,10 +150,8 @@ func (s *Server) Start(addr string) error {
 
 func (s *Server) handleListener() error {
 	var backoff time.Duration
-	var newConn net.Conn
-	var err error
 	for {
-		newConn, err = s.listener.Accept()
+		newConn, err := s.listener.Accept()
 		if err != nil {
 			if s.shutdown.Load() {
 				return nil

--- a/server_test.go
+++ b/server_test.go
@@ -243,7 +243,7 @@ func TestServerMultipleConnections(t *testing.T) {
 			wg.Done()
 		}()
 
-		time.Sleep(time.Millisecond * time.Duration(500*num))
+		time.Sleep(time.Millisecond * time.Duration(50*num))
 
 		clients := make([]*Client, num)
 		for i := 0; i < num; i++ {

--- a/server_test.go
+++ b/server_test.go
@@ -278,7 +278,7 @@ func TestServerMultipleConnections(t *testing.T) {
 					assert.NoError(t, err)
 				}
 				<-finished[idx]
-				err = clients[idx].Close()
+				err := clients[idx].Close()
 				assert.NoError(t, err)
 				clientWg.Done()
 				packet.Put(p)

--- a/server_test.go
+++ b/server_test.go
@@ -30,7 +30,6 @@ import (
 	"net"
 	"sync"
 	"testing"
-	"time"
 )
 
 // trunk-ignore-all(golangci-lint/staticcheck)
@@ -245,7 +244,8 @@ func TestServerMultipleConnections(t *testing.T) {
 			wg.Done()
 		}()
 
-		time.Sleep(time.Millisecond * time.Duration(50*num))
+		<-s.started()
+		listenAddr := s.listener.Addr().String()
 
 		clients := make([]*Client, num)
 		for i := 0; i < num; i++ {
@@ -254,7 +254,7 @@ func TestServerMultipleConnections(t *testing.T) {
 			_, err = clients[i].Raw()
 			assert.ErrorIs(t, ConnectionNotInitialized, err)
 
-			err = clients[i].Connect(s.listener.Addr().String())
+			err = clients[i].Connect(listenAddr)
 			require.NoError(t, err)
 		}
 

--- a/server_test.go
+++ b/server_test.go
@@ -21,13 +21,17 @@ import (
 	"crypto/rand"
 	"github.com/loopholelabs/frisbee/pkg/metadata"
 	"github.com/loopholelabs/frisbee/pkg/packet"
+	"github.com/loopholelabs/testing/conn"
 	"github.com/loopholelabs/testing/conn/pair"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"net"
+	"os"
+	"sync"
 	"testing"
+	"time"
 )
 
 // trunk-ignore-all(golangci-lint/staticcheck)
@@ -205,98 +209,100 @@ func TestServerStaleClose(t *testing.T) {
 func TestServerMultipleConnections(t *testing.T) {
 	t.Parallel()
 
-	const testSize = 100
+	const testSize = 2
 	const packetSize = 512
-	clientHandlerTable := make(HandlerTable)
-	clientHandlerTable2 := make(HandlerTable)
-	serverHandlerTable := make(HandlerTable)
 
-	finished := make(chan struct{}, 2)
-
-	serverHandlerTable[metadata.PacketPing] = func(_ context.Context, incoming *packet.Packet) (outgoing *packet.Packet, action Action) {
-		if incoming.Metadata.Id == testSize-1 {
-			outgoing = incoming
-			action = CLOSE
+	runner := func(t *testing.T, num int) {
+		finished := make(chan struct{}, num)
+		clientTables := make([]HandlerTable, num)
+		for i := 0; i < num; i++ {
+			clientTables[i] = make(HandlerTable)
+			clientTables[i][metadata.PacketPing] = func(_ context.Context, _ *packet.Packet) (outgoing *packet.Packet, action Action) {
+				finished <- struct{}{}
+				return
+			}
 		}
-		return
-	}
+		serverHandlerTable := make(HandlerTable)
+		serverHandlerTable[metadata.PacketPing] = func(_ context.Context, incoming *packet.Packet) (outgoing *packet.Packet, action Action) {
+			if incoming.Metadata.Id == testSize-1 {
+				outgoing = incoming
+				action = CLOSE
+			}
+			return
+		}
 
-	clientHandlerTable[metadata.PacketPing] = func(_ context.Context, _ *packet.Packet) (outgoing *packet.Packet, action Action) {
-		finished <- struct{}{}
-		return
-	}
-	clientHandlerTable2[metadata.PacketPing] = func(_ context.Context, _ *packet.Packet) (outgoing *packet.Packet, action Action) {
-		finished <- struct{}{}
-		return
-	}
+		emptyLogger := zerolog.New(os.Stdout)
+		s, err := NewServer(serverHandlerTable, WithLogger(&emptyLogger))
+		require.NoError(t, err)
 
-	emptyLogger := zerolog.New(ioutil.Discard)
-	s, err := NewServer(serverHandlerTable, WithLogger(&emptyLogger))
-	require.NoError(t, err)
+		var wg sync.WaitGroup
 
-	var serverConn net.Conn
-	var clientConn net.Conn
+		wg.Add(1)
+		go func() {
+			err := s.Start(conn.Listen)
+			require.NoError(t, err)
+			wg.Done()
+		}()
 
-	serverConn, clientConn, err = pair.New()
-	require.NoError(t, err)
+		time.Sleep(time.Second)
 
-	go s.ServeConn(serverConn)
+		clients := make([]*Client, num)
+		for i := 0; i < num; i++ {
+			c, err := NewClient(clientTables[i], context.Background(), WithLogger(&emptyLogger))
+			assert.NoError(t, err)
+			_, err = c.Raw()
+			assert.ErrorIs(t, ConnectionNotInitialized, err)
 
-	c, err := NewClient(clientHandlerTable, context.Background(), WithLogger(&emptyLogger))
-	assert.NoError(t, err)
-	_, err = c.Raw()
-	assert.ErrorIs(t, ConnectionNotInitialized, err)
+			err = c.Connect(s.listener.Addr().String())
+			require.NoError(t, err)
 
-	err = c.FromConn(clientConn)
-	require.NoError(t, err)
+			clients[i] = c
+		}
 
-	c2, err := NewClient(clientHandlerTable2, context.Background(), WithLogger(&emptyLogger))
-	assert.NoError(t, err)
-	_, err = c2.Raw()
-	assert.ErrorIs(t, ConnectionNotInitialized, err)
-
-	serverConn, clientConn, err = pair.New()
-	require.NoError(t, err)
-
-	go s.ServeConn(serverConn)
-
-	err = c2.FromConn(clientConn)
-	require.NoError(t, err)
-
-	assert.NotEqual(t, c.conn, c2.conn)
-
-	data := make([]byte, packetSize)
-	_, _ = rand.Read(data)
-	p := packet.Get()
-	p.Content.Write(data)
-	p.Metadata.ContentLength = packetSize
-	p.Metadata.Operation = metadata.PacketPing
-	assert.Equal(t, data, p.Content.B)
-
-	for q := 0; q < testSize; q++ {
-		p.Metadata.Id = uint16(q)
-		err = c.WritePacket(p)
-		err = c2.WritePacket(p)
+		data := make([]byte, packetSize)
+		_, err = rand.Read(data)
 		assert.NoError(t, err)
+
+		var clientWg sync.WaitGroup
+		for i := 0; i < num; i++ {
+			idx := i
+			clientWg.Add(1)
+			go func() {
+				p := packet.Get()
+				p.Content.Write(data)
+				p.Metadata.ContentLength = packetSize
+				p.Metadata.Operation = metadata.PacketPing
+				assert.Equal(t, data, p.Content.B)
+				t.Logf("Starting %d", idx)
+				for q := 0; q < testSize; q++ {
+					p.Metadata.Id = uint16(q)
+					err := clients[idx].WritePacket(p)
+					assert.NoError(t, err)
+				}
+				t.Logf("Waiting %d", idx)
+				<-finished
+				t.Logf("Done %d", idx)
+				err = clients[idx].Close()
+				assert.NoError(t, err)
+				clientWg.Done()
+				packet.Put(p)
+			}()
+		}
+
+		clientWg.Wait()
+
+		err = s.Shutdown()
+		assert.NoError(t, err)
+		wg.Wait()
+
 	}
-	packet.Put(p)
-	<-finished
-	<-finished
 
-	_, err = c.conn.ReadPacket()
-	assert.ErrorIs(t, err, ConnectionClosed)
+	t.Run("1", func(t *testing.T) { runner(t, 1) })
+	t.Run("2", func(t *testing.T) { runner(t, 2) })
+	t.Run("3", func(t *testing.T) { runner(t, 3) })
+	t.Run("5", func(t *testing.T) { runner(t, 5) })
+	t.Run("10", func(t *testing.T) { runner(t, 10) })
 
-	_, err = c2.conn.ReadPacket()
-	assert.ErrorIs(t, err, ConnectionClosed)
-
-	err = c.Close()
-	assert.NoError(t, err)
-
-	err = c2.Close()
-	assert.NoError(t, err)
-
-	err = s.Shutdown()
-	assert.NoError(t, err)
 }
 
 func BenchmarkThroughputServer(b *testing.B) {


### PR DESCRIPTION
## Description

This PR fixes an issue where the Frisbee server would accidentally overwrite various connections with one another because of a pointer reuse issue. 

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] Bug fix (non-breaking change which fixes an issue) [title: 'fix:']

## Testing

Please make sure that existing test cases pass (with `go test ./... -race` and `go test -bench=. ./... -race`),
and if required please add new test cases and list them below:

- [x] TestServerMultipleConnections

## Benchmarking

Frisbee tries to adhere to strict performance requirements, so please make sure to run `go test -bench=. ./...` and paste the results below:

### Benchmarking Results:

```shell
goos: darwin
goarch: arm64
pkg: github.com/loopholelabs/frisbee
BenchmarkAsyncThroughputPipe/32_Bytes-10           98193             10480 ns/op         305.36 MB/s         458 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/512_Bytes-10          91071             12989 ns/op        3941.93 MB/s         453 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/1024_Bytes-10         60310             19909 ns/op        5143.35 MB/s         468 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/2048_Bytes-10         44275             26945 ns/op        7600.81 MB/s         476 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/4096_Bytes-10         26920             44618 ns/op        9180.10 MB/s         541 B/op          9 allocs/op
BenchmarkAsyncThroughputNetwork/32_Bytes-10        53298             22776 ns/op         140.50 MB/s         259 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/512_Bytes-10       43454             27742 ns/op        1845.54 MB/s         259 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/1024_Bytes-10      34974             34293 ns/op        2986.03 MB/s         260 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/2048_Bytes-10      26864             46269 ns/op        4426.27 MB/s         262 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/4096_Bytes-10      18454             64781 ns/op        6322.85 MB/s         265 B/op          4 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/1_Pair,_32_Bytes-10                55996             21469 ns/op         149.05 MB/s         302 B/op          4 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/2_Pair,_32_Bytes-10                46688             25580 ns/op         125.10 MB/s         627 B/op          8 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/5_Pair,_32_Bytes-10                33877             34678 ns/op          92.28 MB/s        1663 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/10_Pair,_32_Bytes-10               14608             83482 ns/op          38.33 MB/s        4263 B/op         40 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/Half_CPU_Pair,_32_Bytes-10         32216             35047 ns/op          91.31 MB/s        1678 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/CPU_Pair,_32_Bytes-10              14923             78849 ns/op          40.58 MB/s        4221 B/op         40 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/Double_CPU_Pair,_32_Bytes-10                7328            157245 ns/op          20.35 MB/s       11791 B/op         81 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/1_Pair,_512_Bytes-10                       42998             27168 ns/op        1884.58 MB/s         314 B/op          4 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/2_Pair,_512_Bytes-10                       38607             31047 ns/op        1649.09 MB/s         649 B/op          8 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/5_Pair,_512_Bytes-10                       23839             45434 ns/op        1126.91 MB/s        1810 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/10_Pair,_512_Bytes-10                      11554            105123 ns/op         487.05 MB/s        4696 B/op         40 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/Half_CPU_Pair,_512_Bytes-10                24847             45026 ns/op        1137.11 MB/s        1795 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/CPU_Pair,_512_Bytes-10                     11311            105886 ns/op         483.54 MB/s        4748 B/op         40 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/Double_CPU_Pair,_512_Bytes-10               5938            210075 ns/op         243.72 MB/s       13331 B/op         81 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/1_Pair,_4096_Bytes-10                      18312             65027 ns/op        6298.92 MB/s         405 B/op          4 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/2_Pair,_4096_Bytes-10                      16814             69161 ns/op        5922.45 MB/s         863 B/op          8 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/5_Pair,_4096_Bytes-10                       4096            267612 ns/op        1530.57 MB/s        4762 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/10_Pair,_4096_Bytes-10                      2084            551874 ns/op         742.20 MB/s       15892 B/op         42 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/Half_CPU_Pair,_4096_Bytes-10                4041            276157 ns/op        1483.21 MB/s        4783 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/CPU_Pair,_4096_Bytes-10                     2046            562262 ns/op         728.49 MB/s       15885 B/op         42 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/Double_CPU_Pair,_4096_Bytes-10              1032           1151635 ns/op         355.67 MB/s       57653 B/op         88 allocs/op
BenchmarkThroughputClient/test-10                                                    100          10498494 ns/op        3196.07 MB/s        8791 B/op         25 allocs/op
BenchmarkThroughputResponseClient/test-10                                             90          11218144 ns/op        2991.04 MB/s        9952 B/op         20 allocs/op
BenchmarkThroughputServer/test-10                                                    100          10412150 ns/op        3222.57 MB/s        9578 B/op         34 allocs/op
BenchmarkThroughputResponseServer/test-10                                            100          10527189 ns/op        3187.36 MB/s       10174 B/op         27 allocs/op
BenchmarkSyncThroughputPipe/32_Bytes-10                                             8928            130827 ns/op          24.46 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/512_Bytes-10                                            9223            129541 ns/op         395.24 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/1024_Bytes-10                                           9159            128715 ns/op         795.56 MB/s        1859 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/2048_Bytes-10                                           9172            129917 ns/op        1576.39 MB/s        1861 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/4096_Bytes-10                                           8890            134855 ns/op        3037.33 MB/s        1864 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/32_Bytes-10                                          3555            342644 ns/op           9.34 MB/s        1858 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/512_Bytes-10                                         3009            366909 ns/op         139.54 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/1024_Bytes-10                                        3044            395673 ns/op         258.80 MB/s        1860 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/2048_Bytes-10                                        2827            405573 ns/op         504.96 MB/s        1862 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/4096_Bytes-10                                        2784            398539 ns/op        1027.75 MB/s        1865 B/op        204 allocs/op
BenchmarkAsyncThroughputLarge/1MB-10                                                 171           6652837 ns/op        15761.34 MB/s      51821 B/op          4 allocs/op
BenchmarkAsyncThroughputLarge/2MB-10                                                  57          21809973 ns/op        9615.56 MB/s      236871 B/op          5 allocs/op
BenchmarkAsyncThroughputLarge/4MB-10                                                  20          52123140 ns/op        8046.91 MB/s      643704 B/op          6 allocs/op
BenchmarkAsyncThroughputLarge/8MB-10                                                  10         106267738 ns/op        7893.84 MB/s     3744882 B/op          9 allocs/op
BenchmarkAsyncThroughputLarge/16MB-10                                                  5         234434975 ns/op        7156.45 MB/s    10592124 B/op         12 allocs/op
BenchmarkSyncThroughputLarge/1MB-10                                                  100          12734685 ns/op        8234.02 MB/s     1679455 B/op        214 allocs/op
BenchmarkSyncThroughputLarge/2MB-10                                                   48          23137381 ns/op        9063.91 MB/s     1546518 B/op        209 allocs/op
BenchmarkSyncThroughputLarge/4MB-10                                                   20          50427942 ns/op        8317.42 MB/s    23223265 B/op        246 allocs/op
BenchmarkSyncThroughputLarge/8MB-10                                                   10         102233679 ns/op        8205.33 MB/s    20854443 B/op        225 allocs/op
BenchmarkSyncThroughputLarge/16MB-10                                                   5         220727392 ns/op        7600.88 MB/s    61584179 B/op        231 allocs/op
BenchmarkTCPThroughput/32_Bytes-10                                                 22876             51848 ns/op          61.72 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/512_Bytes-10                                                14374             83171 ns/op         615.60 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/1024_Bytes-10                                                9836            122753 ns/op         834.19 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/2048_Bytes-10                                                5912            208611 ns/op         981.73 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/4096_Bytes-10                                                3138            386273 ns/op        1060.39 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/1MB-10                                                         85          12524959 ns/op        8371.89 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/2MB-10                                                         44          23705317 ns/op        8846.76 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/4MB-10                                                         24          47653892 ns/op        8801.60 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/8MB-10                                                         10         106483958 ns/op        7877.81 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/16MB-10                                                         5         223026100 ns/op        7522.53 MB/s         304 B/op          4 allocs/op
PASS
ok      github.com/loopholelabs/frisbee 110.046s
?       github.com/loopholelabs/frisbee/internal/dialer [no test files]
PASS
ok      github.com/loopholelabs/frisbee/internal/queue  0.174s
?       github.com/loopholelabs/frisbee/pkg/content     [no test files]
goos: darwin
goarch: arm64
pkg: github.com/loopholelabs/frisbee/pkg/metadata
BenchmarkEncodeHandler-10               200699479                5.958 ns/op
BenchmarkDecodeHandler-10               252026008                4.785 ns/op
BenchmarkEncodeDecodeHandler-10         85717089                13.68 ns/op
BenchmarkEncode-10                      221858586                5.393 ns/op
BenchmarkDecode-10                      311026202                3.861 ns/op
BenchmarkEncodeDecode-10                100000000               11.38 ns/op
PASS
ok      github.com/loopholelabs/frisbee/pkg/metadata    9.243s
PASS
ok      github.com/loopholelabs/frisbee/pkg/packet      0.106s
?       github.com/loopholelabs/frisbee/protoc-gen-frpc [no test files]
?       github.com/loopholelabs/frisbee/protoc-gen-frpc/internal/utils  [no test files]
?       github.com/loopholelabs/frisbee/protoc-gen-frpc/internal/version        [no test files]
?       github.com/loopholelabs/frisbee/protoc-gen-frpc/pkg/generator   [no test files]
?       github.com/loopholelabs/frisbee/protoc-gen-frpc/templates       [no test files]
```

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `trunk check` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
